### PR TITLE
PR: Improve and simplify instrumentation, add missing tests

### DIFF
--- a/.github/workflows/jobberknoll.yml
+++ b/.github/workflows/jobberknoll.yml
@@ -36,9 +36,11 @@ jobs:
           deno-version: "~2.1"
       - name: Format code
         run: deno fmt --check
+      - name: Typecheck code
+        run: deno check .
       - name: Lint code
         run: deno lint
       - name: Test code
-        run: deno test
+        run: deno run test
       - name: Compile code
         run: deno task compile

--- a/implementation/jobberknoll/.gitignore
+++ b/implementation/jobberknoll/.gitignore
@@ -1,2 +1,5 @@
 # Compiled executable
 /jobberknoll
+
+# Test coverage
+/coverage

--- a/implementation/jobberknoll/README.md
+++ b/implementation/jobberknoll/README.md
@@ -45,7 +45,7 @@
 | ------------------------------- | ---------- |
 | Account Repository (PostgreSQL) | 🟩         |
 | Email Sending Service (AWS SQS) | 🟥         |
-| Logging                         | 🟨         |
+| Logging                         | 🟩         |
 
 ## ADRs
 

--- a/implementation/jobberknoll/api/api.ts
+++ b/implementation/jobberknoll/api/api.ts
@@ -3,9 +3,9 @@ import type { Logger, Service } from "@jobberknoll/app";
 import { ExtController } from "~/ext/ext-controller.ts";
 import { IntController } from "~/int/int-controller.ts";
 
-export function buildApi(service: Service, logger: Logger): OpenAPIHono {
-  const intController = new IntController(service, logger);
-  const extController = new ExtController(service, logger);
+export function buildApi(logger: Logger, service: Service): OpenAPIHono {
+  const intController = new IntController(logger, service);
+  const extController = new ExtController(logger, service);
 
   return new OpenAPIHono()
     .route(intController.prefix, intController.routes)

--- a/implementation/jobberknoll/api/ext/authorization.test.ts
+++ b/implementation/jobberknoll/api/ext/authorization.test.ts
@@ -1,1 +1,73 @@
-// TODO: Implement missing tests
+import { createRoute } from "@hono/zod-openapi";
+import { USER_ROLES, type UserRole } from "@jobberknoll/app";
+import { TestLogger } from "@jobberknoll/infra";
+import { assert, assertEquals } from "@std/assert";
+import { createJkApp, type JkHandler } from "~/shared/hooks.ts";
+import { authorize, isValid } from "./authorization.ts";
+
+for (const expectedRole of [...USER_ROLES, "member"] as const) {
+  Deno.test(`isValid should reject invalid user roles if expecting ${expectedRole}`, () => {
+    assert(!isValid(expectedRole, undefined));
+    assert(!isValid(expectedRole, ""));
+    assert(!isValid(expectedRole, "invalid"));
+    assert(!isValid(expectedRole, "something"));
+    assert(!isValid(expectedRole, "member"));
+  });
+}
+
+for (const expectedRole of USER_ROLES) {
+  Deno.test(`isValid should accept ${expectedRole} if expecting ${expectedRole}`, () => {
+    assert(isValid(expectedRole, expectedRole));
+  });
+}
+
+for (const expectedRole of USER_ROLES) {
+  Deno.test(`isValid should reject other roles if expecting ${expectedRole}`, () => {
+    for (const userRole of USER_ROLES.filter((role) => role !== expectedRole)) {
+      assert(!isValid(expectedRole, userRole));
+    }
+  });
+}
+
+Deno.test("isValid should reject guest if expecting member", () => {
+  assert(!isValid("member", "guest"));
+});
+
+for (const userRole of ["admin", "driver", "passenger", "inspector"] as const) {
+  Deno.test(`isValid should accept ${userRole} if expecting member`, () => {
+    assert(isValid("member", userRole));
+  });
+}
+
+function setup(expectedRole: UserRole | "member") {
+  const route = createRoute({
+    method: "get",
+    path: "/path",
+    responses: { 204: { description: "No content." } },
+  });
+  const info = { wasCalled: false };
+  const handler = authorize(expectedRole, (c) => {
+    info.wasCalled = true;
+    return c.body(null, 204);
+  }) satisfies JkHandler<typeof route>;
+  const app = createJkApp(new TestLogger()).openapi(route, handler);
+  return { info, app };
+}
+
+Deno.test("authorize should call the handler if the user is authorized", async () => {
+  const { info, app } = setup("admin");
+
+  const res = await app.request("/path", { headers: { "jp-user-role": "admin" } });
+
+  assertEquals(res.status, 204);
+  assert(info.wasCalled);
+});
+
+Deno.test("authorize should not call the handler if the user is not authorized", async () => {
+  const { info, app } = setup("admin");
+
+  const res = await app.request("/path", { headers: { "jp-user-role": "guest" } });
+
+  assertEquals(res.status, 401);
+  assert(!info.wasCalled);
+});

--- a/implementation/jobberknoll/api/ext/authorization.ts
+++ b/implementation/jobberknoll/api/ext/authorization.ts
@@ -1,6 +1,7 @@
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
 import { USER_ROLES, type UserRole } from "@jobberknoll/app";
 import type { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
+import type { JkHandler } from "~/shared/hooks.ts";
 
 function isValid(expectedRole: UserRole | "member", userRole: string | undefined): boolean {
   if (!USER_ROLES.includes(userRole as UserRole)) return false; // SAFETY: even if userRole is not a valid UserRole, the check will fail and will never throw (https://github.com/microsoft/TypeScript/issues/26255)
@@ -10,8 +11,8 @@ function isValid(expectedRole: UserRole | "member", userRole: string | undefined
 
 export function authorize<R extends RouteConfig>(
   expectedRole: UserRole | "member",
-  handler: RouteHandler<R>,
-): RouteHandler<R> {
+  handler: JkHandler<R>,
+): JkHandler<R> {
   return (c, next) => {
     const userRole = c.req.header("jp-user-role");
 

--- a/implementation/jobberknoll/api/ext/authorization.ts
+++ b/implementation/jobberknoll/api/ext/authorization.ts
@@ -3,7 +3,7 @@ import { USER_ROLES, type UserRole } from "@jobberknoll/app";
 import type { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
 import type { JkHandler } from "~/shared/hooks.ts";
 
-function isValid(expectedRole: UserRole | "member", userRole: string | undefined): boolean {
+export function isValid(expectedRole: UserRole | "member", userRole: string | undefined): boolean {
   if (!USER_ROLES.includes(userRole as UserRole)) return false; // SAFETY: even if userRole is not a valid UserRole, the check will fail and will never throw (https://github.com/microsoft/TypeScript/issues/26255)
   if (expectedRole === "member") return userRole !== "guest";
   return userRole === expectedRole;

--- a/implementation/jobberknoll/api/ext/contracts/invalid-account-data-dto.ts
+++ b/implementation/jobberknoll/api/ext/contracts/invalid-account-data-dto.ts
@@ -1,5 +1,7 @@
 import type { z } from "@hono/zod-openapi";
-import { errorDto } from "~/shared/openapi.ts";
+import { errorDto, jsonRes } from "~/shared/openapi.ts";
+
+const DESCRIPTION = "Some of the provided account data is invalid.";
 
 export const InvalidAccountDataDto = errorDto(
   "InvalidAccountDataDto",
@@ -8,4 +10,6 @@ export const InvalidAccountDataDto = errorDto(
   "Some of the provided account data is invalid.",
 );
 
-export type InvalidUserDataDto = z.infer<typeof InvalidAccountDataDto>;
+export const InvalidAccountDataResponse = jsonRes(InvalidAccountDataDto, DESCRIPTION);
+
+export type InvalidAccountDataDto = z.infer<typeof InvalidAccountDataDto>;

--- a/implementation/jobberknoll/api/ext/contracts/user-unauthorized-dto.ts
+++ b/implementation/jobberknoll/api/ext/contracts/user-unauthorized-dto.ts
@@ -1,5 +1,7 @@
 import type { z } from "@hono/zod-openapi";
-import { errorDto } from "~/shared/openapi.ts";
+import { errorDto, jsonRes } from "~/shared/openapi.ts";
+
+const DESCRIPTION = "The user does not have access to the resource.";
 
 export const UserUnauthorizedDto = errorDto(
   "UserUnauthorizedDto",
@@ -7,5 +9,7 @@ export const UserUnauthorizedDto = errorDto(
   "user-unauthorized",
   "The user does not have access to the resource.",
 );
+
+export const UserUnauthorizedResponse = jsonRes(UserUnauthorizedDto, DESCRIPTION);
 
 export type UserUnauthorizedDto = z.infer<typeof UserUnauthorizedDto>;

--- a/implementation/jobberknoll/api/ext/ext-controller.ts
+++ b/implementation/jobberknoll/api/ext/ext-controller.ts
@@ -1,9 +1,8 @@
-import type { OpenAPIHono } from "@hono/zod-openapi";
 import type { Logger, Service } from "@jobberknoll/app";
 import { SERVICE_VERSION } from "@jobberknoll/core/shared";
 import type { Controller } from "~/shared/controller.ts";
 import { configureDocs } from "~/shared/docs.ts";
-import { createOpenAPIHono } from "~/shared/hooks.ts";
+import { createJkApp, type JkApp } from "~/shared/hooks.ts";
 import * as r from "./routes/mod.ts";
 
 export class ExtController implements Controller {
@@ -11,8 +10,8 @@ export class ExtController implements Controller {
 
   public readonly prefix = "/ext/v1";
 
-  public get routes(): OpenAPIHono {
-    const app = createOpenAPIHono(this.logger)
+  public get routes(): JkApp {
+    const app = createJkApp(this.logger)
       .openapi(
         r.createAccountRoute,
         r.createAccountHandler(this.service.createAccount),

--- a/implementation/jobberknoll/api/ext/ext-controller.ts
+++ b/implementation/jobberknoll/api/ext/ext-controller.ts
@@ -7,7 +7,7 @@ import { createOpenAPIHono } from "~/shared/hooks.ts";
 import * as r from "./routes/mod.ts";
 
 export class ExtController implements Controller {
-  public constructor(private readonly service: Service, private readonly logger: Logger) {}
+  public constructor(private readonly logger: Logger, private readonly service: Service) {}
 
   public readonly prefix = "/ext/v1";
 

--- a/implementation/jobberknoll/api/ext/openapi.test.ts
+++ b/implementation/jobberknoll/api/ext/openapi.test.ts
@@ -1,1 +1,47 @@
-// TODO: Implement missing tests
+import { uuid } from "@jobberknoll/core/shared";
+import { assert } from "@std/assert";
+import { omit } from "@std/collections";
+import { extHeadersSchema } from "./openapi.ts";
+
+const validExtHeaders = {
+  "jp-user-id": uuid(),
+  "jp-user-role": "guest",
+  "jp-request-id": uuid(),
+  "user-agent": "Phoenix/1.0",
+};
+
+Deno.test("extHeadersSchema should accept valid headers", () => {
+  const result = extHeadersSchema("guest").safeParse(validExtHeaders);
+
+  assert(result.success);
+});
+
+Deno.test("extHeadersSchema should accept missing optional headers", () => {
+  const result = extHeadersSchema("guest").safeParse(omit(validExtHeaders, ["jp-request-id", "user-agent"]));
+
+  assert(result.success);
+});
+
+Deno.test("extHeadersSchema should reject missing required headers", () => {
+  const result = extHeadersSchema("guest").safeParse({});
+
+  assert(!result.success);
+});
+
+Deno.test("extHeadersSchema should reject numerical IDs", () => {
+  const result = extHeadersSchema("guest").safeParse({
+    ...validExtHeaders,
+    "jp-user-id": "123",
+    "jp-request-id": "456",
+  });
+
+  assert(!result.success);
+});
+
+Deno.test("extHeadersSchema should reject invalid roles", () => {
+  for (const role of [undefined, "", "invalid", "something"]) {
+    const result = extHeadersSchema("guest").safeParse({ ...validExtHeaders, "jp-user-role": role });
+
+    assert(!result.success);
+  }
+});

--- a/implementation/jobberknoll/api/ext/routes/create-account-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/create-account-route.ts
@@ -2,9 +2,9 @@ import { createRoute } from "@hono/zod-openapi";
 import type { CreateAccountUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { authorize } from "~/ext/authorization.ts";
-import { CreateAccountDto, InvalidAccountDataDto, UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
+import { CreateAccountDto, InvalidAccountDataResponse, UserUnauthorizedResponse } from "~/ext/contracts/mod.ts";
 import { extHeadersSchema } from "~/ext/openapi.ts";
-import { AccountDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import { AccountDto, SchemaMismatchResponse } from "~/shared/contracts/mod.ts";
 import type { JkHandler } from "~/shared/hooks.ts";
 import { mapAccountToDto } from "~/shared/mappers/mod.ts";
 import { jsonReq, jsonRes } from "~/shared/openapi.ts";
@@ -21,9 +21,9 @@ export const createAccountRoute = createRoute({
   },
   responses: {
     201: jsonRes(AccountDto, "Created a new account."),
-    400: jsonRes(InvalidAccountDataDto, "Some of the provided account data is invalid."),
-    401: jsonRes(UserUnauthorizedDto, "The user does not have access to the resource."),
-    422: jsonRes(SchemaMismatchDto, "The request data did not align with the schema."),
+    400: InvalidAccountDataResponse,
+    401: UserUnauthorizedResponse,
+    422: SchemaMismatchResponse,
   },
 });
 

--- a/implementation/jobberknoll/api/ext/routes/create-account-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/create-account-route.ts
@@ -30,7 +30,7 @@ export function createAccountHandler(createAccount: CreateAccountUseCase): Route
   return authorize("admin", async (c) => {
     const { "jp-request-id": requestId } = c.req.valid("header");
     const createAccountReq = c.req.valid("json");
-    const res = await createAccount.invoke(createAccountReq, requestId);
+    const res = await createAccount.invoke({ requestId }, createAccountReq);
     return isOk(res) ? c.json(mapAccountToDto(res.value), 201) : c.json(res.value, res.value.code);
   });
 }

--- a/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
@@ -2,11 +2,11 @@ import { createRoute } from "@hono/zod-openapi";
 import type { DeleteAccountUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { authorize } from "~/ext/authorization.ts";
-import { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
+import { UserUnauthorizedResponse } from "~/ext/contracts/mod.ts";
 import { extHeadersSchema } from "~/ext/openapi.ts";
-import { AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import { AccountNotFoundResponse, SchemaMismatchResponse } from "~/shared/contracts/mod.ts";
 import type { JkHandler } from "~/shared/hooks.ts";
-import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
+import { IdParamSchema } from "~/shared/openapi.ts";
 
 export const deleteAccountRoute = createRoute({
   method: "delete",
@@ -20,9 +20,9 @@ export const deleteAccountRoute = createRoute({
   },
   responses: {
     204: { description: "Account deleted successfully." },
-    401: jsonRes(UserUnauthorizedDto, "The user does not have access to the resource."),
-    404: jsonRes(AccountNotFoundDto, "The account could not be found."),
-    422: jsonRes(SchemaMismatchDto, "The request data did not align with the schema."),
+    401: UserUnauthorizedResponse,
+    404: AccountNotFoundResponse,
+    422: SchemaMismatchResponse,
   },
 });
 

--- a/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
@@ -29,7 +29,7 @@ export function deleteAccountHandler(deleteAccount: DeleteAccountUseCase): Route
   return authorize("admin", async (c) => {
     const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await deleteAccount.invoke({ accountId }, requestId);
+    const res = await deleteAccount.invoke({ requestId }, { accountId });
     return isOk(res) ? c.body(null, 204) : c.json(res.value, res.value.code);
   });
 }

--- a/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/delete-account-route.ts
@@ -1,10 +1,11 @@
-import { createRoute, type RouteHandler } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import type { DeleteAccountUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { authorize } from "~/ext/authorization.ts";
 import { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
 import { extHeadersSchema } from "~/ext/openapi.ts";
 import { AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import type { JkHandler } from "~/shared/hooks.ts";
 import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
 
 export const deleteAccountRoute = createRoute({
@@ -25,11 +26,10 @@ export const deleteAccountRoute = createRoute({
   },
 });
 
-export function deleteAccountHandler(deleteAccount: DeleteAccountUseCase): RouteHandler<typeof deleteAccountRoute> {
+export function deleteAccountHandler(deleteAccount: DeleteAccountUseCase): JkHandler<typeof deleteAccountRoute> {
   return authorize("admin", async (c) => {
-    const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await deleteAccount.invoke({ requestId }, { accountId });
+    const res = await deleteAccount.invoke(c.get("ctx"), { accountId });
     return isOk(res) ? c.body(null, 204) : c.json(res.value, res.value.code);
   });
 }

--- a/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
@@ -2,9 +2,9 @@ import { createRoute } from "@hono/zod-openapi";
 import type { GetAccountByIdUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { authorize } from "~/ext/authorization.ts";
-import { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
+import { UserUnauthorizedResponse } from "~/ext/contracts/mod.ts";
 import { extHeadersSchema } from "~/ext/openapi.ts";
-import { AccountDto, AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import { AccountDto, AccountNotFoundResponse, SchemaMismatchResponse } from "~/shared/contracts/mod.ts";
 import type { JkHandler } from "~/shared/hooks.ts";
 import { mapAccountToDto } from "~/shared/mappers/mod.ts";
 import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
@@ -21,9 +21,9 @@ export const getAccountByIdRoute = createRoute({
   },
   responses: {
     200: jsonRes(AccountDto, "Retrieved account by ID."),
-    401: jsonRes(UserUnauthorizedDto, "The user does not have access to the resource."),
-    404: jsonRes(AccountNotFoundDto, "The account could not be found."),
-    422: jsonRes(SchemaMismatchDto, "The request data did not align with the schema."),
+    401: UserUnauthorizedResponse,
+    404: AccountNotFoundResponse,
+    422: SchemaMismatchResponse,
   },
 });
 

--- a/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
@@ -30,7 +30,7 @@ export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): Ro
   return authorize("admin", async (c) => {
     const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await getAccountById.invoke({ accountId }, requestId);
+    const res = await getAccountById.invoke({ requestId }, { accountId });
     return isOk(res) ? c.json(mapAccountToDto(res.value), 200) : c.json(res.value, res.value.code);
   });
 }

--- a/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/ext/routes/get-account-by-id-route.ts
@@ -1,10 +1,11 @@
-import { createRoute, type RouteHandler } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import type { GetAccountByIdUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { authorize } from "~/ext/authorization.ts";
 import { UserUnauthorizedDto } from "~/ext/contracts/mod.ts";
 import { extHeadersSchema } from "~/ext/openapi.ts";
 import { AccountDto, AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import type { JkHandler } from "~/shared/hooks.ts";
 import { mapAccountToDto } from "~/shared/mappers/mod.ts";
 import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
 
@@ -26,11 +27,10 @@ export const getAccountByIdRoute = createRoute({
   },
 });
 
-export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): RouteHandler<typeof getAccountByIdRoute> {
+export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): JkHandler<typeof getAccountByIdRoute> {
   return authorize("admin", async (c) => {
-    const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await getAccountById.invoke({ requestId }, { accountId });
+    const res = await getAccountById.invoke(c.get("ctx"), { accountId });
     return isOk(res) ? c.json(mapAccountToDto(res.value), 200) : c.json(res.value, res.value.code);
   });
 }

--- a/implementation/jobberknoll/api/int/int-controller.ts
+++ b/implementation/jobberknoll/api/int/int-controller.ts
@@ -1,9 +1,8 @@
-import type { OpenAPIHono } from "@hono/zod-openapi";
 import type { Logger, Service } from "@jobberknoll/app";
 import { SERVICE_VERSION } from "@jobberknoll/core/shared";
 import type { Controller } from "~/shared/controller.ts";
 import { configureDocs } from "~/shared/docs.ts";
-import { createOpenAPIHono } from "~/shared/hooks.ts";
+import { createJkApp, type JkApp } from "~/shared/hooks.ts";
 import * as r from "./routes/mod.ts";
 
 export class IntController implements Controller {
@@ -11,8 +10,8 @@ export class IntController implements Controller {
 
   public readonly prefix = "/int/v1";
 
-  public get routes(): OpenAPIHono {
-    const app = createOpenAPIHono(this.logger)
+  public get routes(): JkApp {
+    const app = createJkApp(this.logger)
       .openapi(
         r.getHealthRoute,
         r.getHealthHandler(this.service.getHealth),

--- a/implementation/jobberknoll/api/int/int-controller.ts
+++ b/implementation/jobberknoll/api/int/int-controller.ts
@@ -7,7 +7,7 @@ import { createOpenAPIHono } from "~/shared/hooks.ts";
 import * as r from "./routes/mod.ts";
 
 export class IntController implements Controller {
-  public constructor(private readonly service: Service, private readonly logger: Logger) {}
+  public constructor(private readonly logger: Logger, private readonly service: Service) {}
 
   public readonly prefix = "/int/v1";
 

--- a/implementation/jobberknoll/api/int/openapi.test.ts
+++ b/implementation/jobberknoll/api/int/openapi.test.ts
@@ -1,1 +1,35 @@
-// TODO: Implement missing tests
+import { uuid } from "@jobberknoll/core/shared";
+import { assert } from "@std/assert";
+import { IntHeadersSchema } from "./openapi.ts";
+
+const validIntHeaders = {
+  "jp-request-id": uuid(),
+  "user-agent": "Phoenix/1.0",
+};
+
+Deno.test("IntHeadersSchema should accept valid headers", () => {
+  const result = IntHeadersSchema.safeParse(validIntHeaders);
+
+  assert(result.success);
+});
+
+Deno.test("IntHeadersSchema should accept missing optional headers", () => {
+  const result = IntHeadersSchema.safeParse({});
+
+  assert(result.success);
+});
+
+Deno.test("IntHeadersSchema should accept unnecessary headers", () => {
+  const result = IntHeadersSchema.safeParse({ ...validIntHeaders, "jp-user-id": uuid(), "jp-user-role": "admin" });
+
+  assert(result.success);
+});
+
+Deno.test("IntHeadersSchema should reject numerical IDs", () => {
+  const result = IntHeadersSchema.safeParse({
+    ...validIntHeaders,
+    "jp-request-id": "456",
+  });
+
+  assert(!result.success);
+});

--- a/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
@@ -26,7 +26,7 @@ export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): Ro
   return async (c) => {
     const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await getAccountById.invoke({ accountId }, requestId);
+    const res = await getAccountById.invoke({ requestId }, { accountId });
     return isOk(res) ? c.json(mapAccountToDto(res.value), 200) : c.json(res.value, res.value.code);
   };
 }

--- a/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
@@ -1,8 +1,9 @@
-import { createRoute, type RouteHandler } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import type { GetAccountByIdUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { IntHeadersSchema } from "~/int/openapi.ts";
 import { AccountDto, AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import type { JkHandler } from "~/shared/hooks.ts";
 import { mapAccountToDto } from "~/shared/mappers/mod.ts";
 import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
 
@@ -22,11 +23,10 @@ export const getAccountByIdRoute = createRoute({
   },
 });
 
-export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): RouteHandler<typeof getAccountByIdRoute> {
+export function getAccountByIdHandler(getAccountById: GetAccountByIdUseCase): JkHandler<typeof getAccountByIdRoute> {
   return async (c) => {
-    const { "jp-request-id": requestId } = c.req.valid("header");
     const { id: accountId } = c.req.valid("param");
-    const res = await getAccountById.invoke({ requestId }, { accountId });
+    const res = await getAccountById.invoke(c.get("ctx"), { accountId });
     return isOk(res) ? c.json(mapAccountToDto(res.value), 200) : c.json(res.value, res.value.code);
   };
 }

--- a/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
+++ b/implementation/jobberknoll/api/int/routes/get-account-by-id-route.ts
@@ -2,7 +2,7 @@ import { createRoute } from "@hono/zod-openapi";
 import type { GetAccountByIdUseCase } from "@jobberknoll/app";
 import { isOk } from "@jobberknoll/core/shared";
 import { IntHeadersSchema } from "~/int/openapi.ts";
-import { AccountDto, AccountNotFoundDto, SchemaMismatchDto } from "~/shared/contracts/mod.ts";
+import { AccountDto, AccountNotFoundResponse, SchemaMismatchResponse } from "~/shared/contracts/mod.ts";
 import type { JkHandler } from "~/shared/hooks.ts";
 import { mapAccountToDto } from "~/shared/mappers/mod.ts";
 import { IdParamSchema, jsonRes } from "~/shared/openapi.ts";
@@ -18,8 +18,8 @@ export const getAccountByIdRoute = createRoute({
   },
   responses: {
     200: jsonRes(AccountDto, "Retrieved account by ID."),
-    404: jsonRes(AccountNotFoundDto, "The account could not be found."),
-    422: jsonRes(SchemaMismatchDto, "The request data did not align with the schema."),
+    404: AccountNotFoundResponse,
+    422: SchemaMismatchResponse,
   },
 });
 

--- a/implementation/jobberknoll/api/int/routes/get-health-route.ts
+++ b/implementation/jobberknoll/api/int/routes/get-health-route.ts
@@ -24,7 +24,10 @@ export const getHealthRoute = createRoute({
 export function getHealthHandler(getHealth: GetHealthUseCase): RouteHandler<typeof getHealthRoute> {
   return async (c) => {
     const { "jp-request-id": requestId } = c.req.valid("header");
-    const serviceHealth = expect(await getHealth.invoke(null, requestId), "service health request should never fail");
+    const serviceHealth = expect(
+      await getHealth.invoke({ requestId }, null),
+      "service health request should never fail",
+    );
     const code = ["UP", "UNKNOWN"].includes(serviceHealth.status) ? 200 : 503;
     return c.json(serviceHealth, code);
   };

--- a/implementation/jobberknoll/api/int/routes/get-health-route.ts
+++ b/implementation/jobberknoll/api/int/routes/get-health-route.ts
@@ -1,7 +1,8 @@
-import { createRoute, type RouteHandler } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import type { GetHealthUseCase } from "@jobberknoll/app";
 import { expect } from "@jobberknoll/core/shared";
 import { IntHeadersSchema } from "~/int/openapi.ts";
+import type { JkHandler } from "~/shared/hooks.ts";
 import { jsonRes } from "~/shared/openapi.ts";
 import { HealthDto } from "../contracts/mod.ts";
 
@@ -21,13 +22,9 @@ export const getHealthRoute = createRoute({
   },
 });
 
-export function getHealthHandler(getHealth: GetHealthUseCase): RouteHandler<typeof getHealthRoute> {
+export function getHealthHandler(getHealth: GetHealthUseCase): JkHandler<typeof getHealthRoute> {
   return async (c) => {
-    const { "jp-request-id": requestId } = c.req.valid("header");
-    const serviceHealth = expect(
-      await getHealth.invoke({ requestId }, null),
-      "service health request should never fail",
-    );
+    const serviceHealth = expect(await getHealth.invoke(c.get("ctx"), null), "getHealth request should never fail");
     const code = ["UP", "UNKNOWN"].includes(serviceHealth.status) ? 200 : 503;
     return c.json(serviceHealth, code);
   };

--- a/implementation/jobberknoll/api/shared/contracts/account-not-found-dto.ts
+++ b/implementation/jobberknoll/api/shared/contracts/account-not-found-dto.ts
@@ -1,11 +1,15 @@
 import type { z } from "@hono/zod-openapi";
-import { errorDto } from "~/shared/openapi.ts";
+import { errorDto, jsonRes } from "~/shared/openapi.ts";
+
+const DESCRIPTION = "The account could not be found.";
 
 export const AccountNotFoundDto = errorDto(
   "AccountNotFoundDto",
   404,
   "account-not-found",
-  "The account could not be found.",
+  DESCRIPTION,
 );
+
+export const AccountNotFoundResponse = jsonRes(AccountNotFoundDto, DESCRIPTION);
 
 export type AccountNotFoundDto = z.infer<typeof AccountNotFoundDto>;

--- a/implementation/jobberknoll/api/shared/contracts/schema-mismatch-dto.ts
+++ b/implementation/jobberknoll/api/shared/contracts/schema-mismatch-dto.ts
@@ -1,11 +1,15 @@
 import type { z } from "@hono/zod-openapi";
-import { errorDto } from "~/shared/openapi.ts";
+import { errorDto, jsonRes } from "~/shared/openapi.ts";
+
+const DESCRIPTION = "The request data did not align with the schema.";
 
 export const SchemaMismatchDto = errorDto(
   "SchemaMismatchDto",
   422,
   "schema-mismatch",
-  "The request data did not align with the schema.",
+  DESCRIPTION,
 );
+
+export const SchemaMismatchResponse = jsonRes(SchemaMismatchDto, DESCRIPTION);
 
 export type SchemaMismatchDto = z.infer<typeof SchemaMismatchDto>;

--- a/implementation/jobberknoll/api/shared/controller.ts
+++ b/implementation/jobberknoll/api/shared/controller.ts
@@ -1,6 +1,6 @@
-import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { JkApp } from "~/shared/hooks.ts";
 
 export type Controller = {
   prefix: string;
-  routes: OpenAPIHono;
+  routes: JkApp;
 };

--- a/implementation/jobberknoll/api/shared/docs.ts
+++ b/implementation/jobberknoll/api/shared/docs.ts
@@ -1,6 +1,6 @@
 import { swaggerUI } from "@hono/swagger-ui";
-import type { OpenAPIHono } from "@hono/zod-openapi";
 import { apiReference } from "@scalar/hono-api-reference";
+import type { JkApp } from "~/shared/hooks.ts";
 
 type SetupDocsOptions = {
   path: string;
@@ -11,7 +11,7 @@ type SetupDocsOptions = {
 };
 
 export function configureDocs(
-  app: OpenAPIHono,
+  app: JkApp,
   { path, title, version, description, externalDocs }: SetupDocsOptions,
 ) {
   app.get("/docs", (c) =>

--- a/implementation/jobberknoll/api/shared/hooks.ts
+++ b/implementation/jobberknoll/api/shared/hooks.ts
@@ -55,7 +55,7 @@ function loggingMiddlewareFactory(logger: Logger) {
   });
 }
 
-function configureErrorHandler(app: OpenAPIHono, logger: Logger) {
+function configureErrorHandler(logger: Logger, app: OpenAPIHono) {
   app.openAPIRegistry.register("ServerFailureDto", ServerFailureDto);
   app.onError((err, c) => {
     logger.error(null, "onError", { err: err.message });
@@ -75,6 +75,6 @@ export function createOpenAPIHono(logger: Logger): OpenAPIHono {
   const app = new OpenAPIHono({ defaultHook });
   app.use(requestIdMiddleware);
   app.use(loggingMiddlewareFactory(logger));
-  configureErrorHandler(app, logger);
+  configureErrorHandler(logger, app);
   return app;
 }

--- a/implementation/jobberknoll/api/shared/hooks.ts
+++ b/implementation/jobberknoll/api/shared/hooks.ts
@@ -1,11 +1,14 @@
-import { type Hook, OpenAPIHono } from "@hono/zod-openapi";
-import type { Logger } from "@jobberknoll/app";
-import { expect } from "@jobberknoll/core/shared";
+import { type Hook, OpenAPIHono, type RouteConfig, type RouteHandler } from "@hono/zod-openapi";
+import type { Ctx, Logger } from "@jobberknoll/app";
+import { expect, isNone, uuid } from "@jobberknoll/core/shared";
 import { pick } from "@std/collections";
-import type { Env } from "hono";
+import type { Env, HonoRequest } from "hono";
 import { createMiddleware } from "hono/factory";
-import { isNone, uuid } from "../../core/shared/mod.ts";
 import { type SchemaMismatchDto, ServerFailureDto } from "./contracts/mod.ts";
+
+type JkBindings = { Variables: { ctx: Ctx } };
+export type JkHandler<R extends RouteConfig> = RouteHandler<R, JkBindings>;
+export type JkApp = OpenAPIHono<JkBindings>;
 
 const defaultHook: Hook<unknown, Env, string, unknown> = (res, c) => {
   if (!res.success) {
@@ -21,29 +24,31 @@ const defaultHook: Hook<unknown, Env, string, unknown> = (res, c) => {
   }
 };
 
-const requestIdMiddleware = createMiddleware(async (c, next) => {
-  const HEADER_NAME = "jp-request-id";
-  const requestId = c.req.header(HEADER_NAME);
-  if (!requestId || isNone(uuid(requestId))) {
+const REQUEST_ID_HEADER = "jp-request-id";
+
+const expectRequestId = (req: HonoRequest) =>
+  expect(uuid(req.header(REQUEST_ID_HEADER) ?? ""), "requestId should be always set by requestIdMiddleware");
+
+const requestIdMiddleware = createMiddleware<JkBindings>(async (c, next) => {
+  const extracted = c.req.header(REQUEST_ID_HEADER);
+  if (!extracted || isNone(uuid(extracted))) {
     const headers = new Headers(c.req.raw.headers);
-    headers.set(HEADER_NAME, uuid());
+    headers.set(REQUEST_ID_HEADER, uuid());
     c.req.raw = new Request(c.req.raw, { headers });
   }
+  c.set("ctx", { requestId: expectRequestId(c.req) });
   await next();
 });
 
 function loggingMiddlewareFactory(logger: Logger) {
   const extractBody = (r: Request | Response): Promise<unknown | undefined> => r.clone().json().catch(() => undefined);
   return createMiddleware(async (c, next) => {
-    const requestId = expect(
-      uuid(c.req.header("jp-request-id") ?? ""),
-      "requestId should be always set by requestIdMiddleware",
-    );
+    const requestId = expectRequestId(c.req);
     logger.debug(requestId, "http request - start", {
       method: c.req.method,
       route: c.req.routePath,
       url: new URL(c.req.url).pathname + new URL(c.req.url).search,
-      headers: pick(c.req.header(), ["jp-request-id", "jp-user-id", "jp-user-role", "user-agent", "content-type"]),
+      headers: pick(c.req.header(), [REQUEST_ID_HEADER, "jp-user-id", "jp-user-role", "user-agent", "content-type"]),
       body: await extractBody(c.req.raw),
     });
     await next();
@@ -71,10 +76,10 @@ function configureErrorHandler(logger: Logger, app: OpenAPIHono) {
   });
 }
 
-export function createOpenAPIHono(logger: Logger): OpenAPIHono {
+export function createJkApp(logger: Logger): JkApp {
   const app = new OpenAPIHono({ defaultHook });
   app.use(requestIdMiddleware);
   app.use(loggingMiddlewareFactory(logger));
   configureErrorHandler(logger, app);
-  return app;
+  return app as JkApp; // SAFETY: the cast is safe as long as app.use(requestIdMiddleware) is used
 }

--- a/implementation/jobberknoll/api/shared/openapi.test.ts
+++ b/implementation/jobberknoll/api/shared/openapi.test.ts
@@ -1,10 +1,36 @@
 import { z } from "@hono/zod-openapi";
 import { uuid } from "@jobberknoll/core/shared";
 import { assert, assertEquals } from "@std/assert";
-import { errorDto, IdParamSchema, jsonRes } from "./openapi.ts";
+import { errorDto, IdParamSchema, jsonReq, jsonRes, RequestIdSchema, UserAgentSchema } from "./openapi.ts";
+
+const TestSchema = z.literal("test");
+const TestDto = errorDto("TestDto", 400, "test", "A test DTO.");
+
+Deno.test("jsonReq should return a request object which is required by default", () => {
+  const description = "A test schema.";
+
+  const result = jsonReq(TestSchema, description);
+
+  assertEquals(result, {
+    content: { "application/json": { schema: TestSchema } },
+    description,
+    required: true,
+  });
+});
+
+Deno.test("jsonReq should return a request object which is not required when specified", () => {
+  const description = "A test schema.";
+
+  const result = jsonReq(TestSchema, description, false);
+
+  assertEquals(result, {
+    content: { "application/json": { schema: TestSchema } },
+    description,
+    required: false,
+  });
+});
 
 Deno.test("jsonRes should return a response object", () => {
-  const TestSchema = z.literal("test");
   const description = "A test schema.";
 
   const result = jsonRes(TestSchema, description);
@@ -16,7 +42,6 @@ Deno.test("jsonRes should return a response object", () => {
 });
 
 Deno.test("errorDto should accept correct errors", () => {
-  const TestDto = errorDto("TestDto", 400, "test", "A test DTO.");
   const testError = {
     code: 400,
     kind: "test",
@@ -29,8 +54,6 @@ Deno.test("errorDto should accept correct errors", () => {
 });
 
 Deno.test("errorDto should reject mismatched codes and kinds", () => {
-  const TestDto = errorDto("TestDto", 400, "test", "A test DTO.");
-
   for (
     const [code, kind] of [
       [401, "test"],
@@ -44,6 +67,40 @@ Deno.test("errorDto should reject mismatched codes and kinds", () => {
 
     assert(!result.success);
   }
+});
+
+Deno.test("RequestIdSchema should accept correct IDs", () => {
+  const id = uuid();
+
+  const result = RequestIdSchema.safeParse(id);
+
+  assert(result.success);
+});
+
+Deno.test("RequestIdSchema should accept missing IDs", () => {
+  const result = RequestIdSchema.safeParse(undefined);
+
+  assert(result.success);
+});
+
+Deno.test("RequestIdSchema should reject numerical IDs", () => {
+  const id = "123";
+
+  const result = RequestIdSchema.safeParse(id);
+
+  assert(!result.success);
+});
+
+Deno.test("UserAgentSchema should accept any string", () => {
+  const result = UserAgentSchema.safeParse("Phoenix/1.0.0");
+
+  assert(result.success);
+});
+
+Deno.test("UserAgentSchema should accept missing values", () => {
+  const result = UserAgentSchema.safeParse(undefined);
+
+  assert(result.success);
 });
 
 Deno.test("IdParamSchema should accept correct IDs", () => {
@@ -61,5 +118,3 @@ Deno.test("IdParamSchema should reject numerical IDs", () => {
 
   assert(!result.success);
 });
-
-// TODO: Implement missing tests

--- a/implementation/jobberknoll/api/shared/openapi.test.ts
+++ b/implementation/jobberknoll/api/shared/openapi.test.ts
@@ -1,7 +1,7 @@
 import { z } from "@hono/zod-openapi";
 import { uuid } from "@jobberknoll/core/shared";
 import { assert, assertEquals } from "@std/assert";
-import { errorDto, IdParamSchema, jsonReq, jsonRes, RequestIdSchema, UserAgentSchema } from "./openapi.ts";
+import { errorDto, IdParamSchema, jsonReq, jsonRes, RequestIdSchema, UserAgentSchema, UuidSchema } from "./openapi.ts";
 
 const TestSchema = z.literal("test");
 const TestDto = errorDto("TestDto", 400, "test", "A test DTO.");
@@ -67,6 +67,30 @@ Deno.test("errorDto should reject mismatched codes and kinds", () => {
 
     assert(!result.success);
   }
+});
+
+Deno.test("UuidSchema should accept correct IDs", () => {
+  const id = uuid();
+
+  const result = UuidSchema.safeParse(id);
+
+  assert(result.success);
+});
+
+Deno.test("UuidSchema should reject numerical IDs", () => {
+  const id = "123";
+
+  const result = UuidSchema.safeParse(id);
+
+  assert(!result.success);
+});
+
+Deno.test("UuidSchema should reject IDs with wrong version", () => {
+  const id = "1be75dc9-ac00-45f8-b015-b64d007abf84";
+
+  const result = UuidSchema.safeParse(id);
+
+  assert(!result.success);
 });
 
 Deno.test("RequestIdSchema should accept correct IDs", () => {

--- a/implementation/jobberknoll/app/interfaces/account-repo.ts
+++ b/implementation/jobberknoll/app/interfaces/account-repo.ts
@@ -12,14 +12,14 @@ export abstract class AccountRepo {
   }
 
   protected abstract handleCreateAccount(account: Account): Promise<void>;
-  public createAccount: (ctx: Ctx, account: Account) => Promise<void>;
+  public readonly createAccount: (ctx: Ctx, account: Account) => Promise<void>;
 
   protected abstract handleIsEmailTaken(email: string): Promise<boolean>;
-  public isEmailTaken: (ctx: Ctx, email: string) => Promise<boolean>;
+  public readonly isEmailTaken: (ctx: Ctx, email: string) => Promise<boolean>;
 
   protected abstract handleGetAccountById(id: UUID): Promise<Result<Account, AccountNotFoundError>>;
-  public getAccountById: (ctx: Ctx, id: UUID) => Promise<Result<Account, AccountNotFoundError>>;
+  public readonly getAccountById: (ctx: Ctx, id: UUID) => Promise<Result<Account, AccountNotFoundError>>;
 
   protected abstract handleDeleteAccount(id: UUID): Promise<Option<AccountNotFoundError>>;
-  public deleteAccount: (ctx: Ctx, id: UUID) => Promise<Option<AccountNotFoundError>>;
+  public readonly deleteAccount: (ctx: Ctx, id: UUID) => Promise<Option<AccountNotFoundError>>;
 }

--- a/implementation/jobberknoll/app/interfaces/account-repo.ts
+++ b/implementation/jobberknoll/app/interfaces/account-repo.ts
@@ -1,45 +1,25 @@
 import type { Account, AccountNotFoundError } from "@jobberknoll/core/domain";
 import type { Option, Result, UUID } from "@jobberknoll/core/shared";
+import type { Ctx } from "../shared/ctx.ts";
 import type { Logger } from "./logger.ts";
 
 export abstract class AccountRepo {
-  public constructor(private readonly logger: Logger) {}
-
-  // TODO: Currently, requestId is not passed to the AccountRepo, because UseCase discards it :(
-  // TODO: Also, this can be moved to a separate class, so that it can be reused by other infra classes
-  private instrument<A extends unknown[], R>(name: string, handler: (...a: A) => Promise<R>): (...a: A) => Promise<R> {
-    const method = `${this.constructor.name}#${name}`;
-    return async (...args) => {
-      this.logger.debug(null, `${method} - start`, { args });
-
-      const res = await handler.bind(this)(...args);
-
-      this.logger.debug(null, `${method} - end`, { res });
-      return res;
-    };
+  public constructor(logger: Logger) {
+    this.createAccount = logger.instrument(this, this.handleCreateAccount);
+    this.isEmailTaken = logger.instrument(this, this.handleIsEmailTaken);
+    this.getAccountById = logger.instrument(this, this.handleGetAccountById);
+    this.deleteAccount = logger.instrument(this, this.handleDeleteAccount);
   }
 
   protected abstract handleCreateAccount(account: Account): Promise<void>;
-  public createAccount: (account: Account) => Promise<void> = this.instrument(
-    "createAccount",
-    this.handleCreateAccount,
-  );
+  public createAccount: (ctx: Ctx, account: Account) => Promise<void>;
 
   protected abstract handleIsEmailTaken(email: string): Promise<boolean>;
-  public isEmailTaken: (email: string) => Promise<boolean> = this.instrument(
-    "isEmailTaken",
-    this.handleIsEmailTaken,
-  );
+  public isEmailTaken: (ctx: Ctx, email: string) => Promise<boolean>;
 
   protected abstract handleGetAccountById(id: UUID): Promise<Result<Account, AccountNotFoundError>>;
-  public getAccountById: (id: UUID) => Promise<Result<Account, AccountNotFoundError>> = this.instrument(
-    "getAccountById",
-    this.handleGetAccountById,
-  );
+  public getAccountById: (ctx: Ctx, id: UUID) => Promise<Result<Account, AccountNotFoundError>>;
 
   protected abstract handleDeleteAccount(id: UUID): Promise<Option<AccountNotFoundError>>;
-  public deleteAccount: (id: UUID) => Promise<Option<AccountNotFoundError>> = this.instrument(
-    "deleteAccount",
-    this.handleDeleteAccount,
-  );
+  public deleteAccount: (ctx: Ctx, id: UUID) => Promise<Option<AccountNotFoundError>>;
 }

--- a/implementation/jobberknoll/app/interfaces/logger.test.ts
+++ b/implementation/jobberknoll/app/interfaces/logger.test.ts
@@ -1,0 +1,46 @@
+import { TestLogger } from "@jobberknoll/infra";
+import { assert, assertEquals } from "@std/assert";
+import { newCtx } from "~/mod.ts";
+import type { Ctx } from "~/shared/mod.ts";
+import type { Logger } from "./logger.ts";
+
+class SampleInfra {
+  public constructor(logger: Logger) {
+    this.instrumentedMethod = logger.instrument(this, this.instrumentedHandler);
+    this.propagatedMethod = logger.propagate(this, this.propagatedHandler);
+  }
+
+  public readonly instrumentedMethod: (ctx: Ctx, arg1: string, arg2: number) => Promise<string>;
+  private instrumentedHandler(arg1: string, arg2: number): Promise<string> {
+    return Promise.resolve(`${arg1} ${arg2}`);
+  }
+
+  public readonly propagatedMethod: (ctx: Ctx, arg1: string, arg2: number) => Promise<string>;
+  private propagatedHandler(ctx: Ctx, arg1: string, arg2: number): Promise<string> {
+    return Promise.resolve(`${ctx.requestId} ${arg1} ${arg2}`);
+  }
+}
+
+Deno.test("instrument should correctly wrap a handler function with logging", async () => {
+  const logger = new TestLogger();
+  const infra = new SampleInfra(logger);
+  const ctx = newCtx();
+
+  const result = await infra.instrumentedMethod(ctx, "hello", 42);
+
+  assertEquals(result, "hello 42");
+  assert(logger.matches("SampleInfra#instrumentedHandler - start", { args: ["hello", 42] }, ctx.requestId));
+  assert(logger.matches("SampleInfra#instrumentedHandler - end", { res: "hello 42" }, ctx.requestId));
+});
+
+Deno.test("propagate should correctly wrap a handler function with logging", async () => {
+  const logger = new TestLogger();
+  const infra = new SampleInfra(logger);
+  const ctx = newCtx();
+
+  const result = await infra.propagatedMethod(ctx, "hello", 42);
+
+  assertEquals(result, `${ctx.requestId} hello 42`);
+  assert(logger.matches("SampleInfra#propagatedHandler - start", { args: ["hello", 42] }, ctx.requestId));
+  assert(logger.matches("SampleInfra#propagatedHandler - end", { res: `${ctx.requestId} hello 42` }, ctx.requestId));
+});

--- a/implementation/jobberknoll/app/interfaces/logger.ts
+++ b/implementation/jobberknoll/app/interfaces/logger.ts
@@ -49,10 +49,10 @@ export abstract class Logger {
     };
   }
 
-  public debug: LogMethod = this.logMethod("debug");
-  public info: LogMethod = this.logMethod("info");
-  public warn: LogMethod = this.logMethod("warn");
-  public error: LogMethod = this.logMethod("error");
+  public readonly debug: LogMethod = this.logMethod("debug");
+  public readonly info: LogMethod = this.logMethod("info");
+  public readonly warn: LogMethod = this.logMethod("warn");
+  public readonly error: LogMethod = this.logMethod("error");
 
   /**
    * Wraps a handler function with logging and returns a new function DROPPING the context.

--- a/implementation/jobberknoll/app/security/hash.test.ts
+++ b/implementation/jobberknoll/app/security/hash.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "@std/assert";
+import { sha256 } from "./hash.ts";
+
+Deno.test("sha256 should return the correct hash", async () => {
+  for (
+    const [input, expected] of [
+      ["", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+      ["test", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"],
+      ["hello world", "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"],
+    ]
+  ) {
+    const actual = await sha256(input);
+
+    assertEquals(actual, expected);
+  }
+});

--- a/implementation/jobberknoll/app/security/redaction.test.ts
+++ b/implementation/jobberknoll/app/security/redaction.test.ts
@@ -1,0 +1,28 @@
+import { assert, assertEquals } from "@std/assert";
+import { redactText } from "./redaction.ts";
+
+Deno.test("redactText should redact the contents", async () => {
+  for (const input of ["abcd", "test", "hello world"]) {
+    const actual = await redactText(input);
+
+    assert(!actual.includes(input));
+    assert(!input.includes(actual));
+    assert(actual.includes("REDACTED"));
+    assert(actual.startsWith("["));
+    assert(actual.endsWith("]"));
+  }
+});
+
+Deno.test("redactText should redact empty strings", async () => {
+  const actual = await redactText("");
+
+  assert(actual.includes("REDACTED"));
+});
+
+Deno.test("redactText should produce the same output for the same input", async () => {
+  const input = "test";
+  const actual1 = await redactText(input);
+  const actual2 = await redactText(input);
+
+  assertEquals(actual1, actual2);
+});

--- a/implementation/jobberknoll/app/security/redaction.test.ts
+++ b/implementation/jobberknoll/app/security/redaction.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
-import { redactText } from "./redaction.ts";
+import { redactSensitiveKeysDeep, redactText } from "./redaction.ts";
 
 Deno.test("redactText should redact the contents", async () => {
   for (const input of ["abcd", "test", "hello world"]) {
@@ -25,4 +25,55 @@ Deno.test("redactText should produce the same output for the same input", async 
   const actual2 = await redactText(input);
 
   assertEquals(actual1, actual2);
+});
+
+Deno.test("redactSensitiveKeysDeep should redact keys from the top level", async () => {
+  const object = {
+    databaseUrl: "SECRET_DATABASE_URL",
+    fullName: "John Doe",
+    email: "john.doe@example.com",
+    password: 123456,
+    hashedPassword: "$2a$12$9ANxmspzFpoEN.4hCKnuue.obvvT1s3GRIO.rz04ZJlfsLVMvID/K",
+    phoneNumber: "123456789",
+  };
+
+  const data = JSON.stringify(await redactSensitiveKeysDeep(object));
+
+  for (const value of Object.values(object)) {
+    assert(!data.includes(JSON.stringify(value)));
+  }
+});
+
+Deno.test("redactSensitiveKeysDeep should retain non-sensitive keys", async () => {
+  const object = {
+    key: 123,
+    something: "else",
+    nested: {
+      key: 456,
+      another: "thing",
+    },
+  };
+
+  const data = JSON.stringify(await redactSensitiveKeysDeep(object));
+
+  for (const value of Object.values(object)) {
+    assert(data.includes(JSON.stringify(value)));
+  }
+});
+
+Deno.test("redactSensitiveKeysDeep should redact keys from nested objects", async () => {
+  const object = {
+    nested: {
+      databaseUrl: "SECRET",
+    },
+    deeply: {
+      nested: {
+        fullName: "SECRET",
+      },
+    },
+  };
+
+  const data = JSON.stringify(await redactSensitiveKeysDeep(object));
+
+  assert(!data.includes("SECRET"));
 });

--- a/implementation/jobberknoll/app/service.ts
+++ b/implementation/jobberknoll/app/service.ts
@@ -8,10 +8,10 @@ export type Service = {
   getHealth: c.GetHealthUseCase;
 };
 
-export function buildService(accountRepo: AccountRepo, logger: Logger): Service {
-  const createAccount = new c.CreateAccountUseCase(accountRepo, logger);
-  const deleteAccount = new c.DeleteAccountUseCase(accountRepo, logger);
-  const getAccountById = new c.GetAccountByIdUseCase(accountRepo, logger);
+export function buildService(logger: Logger, accountRepo: AccountRepo): Service {
+  const createAccount = new c.CreateAccountUseCase(logger, accountRepo);
+  const deleteAccount = new c.DeleteAccountUseCase(logger, accountRepo);
+  const getAccountById = new c.GetAccountByIdUseCase(logger, accountRepo);
   const getHealth = new c.GetHealthUseCase(logger);
 
   return {

--- a/implementation/jobberknoll/app/shared/ctx.test.ts
+++ b/implementation/jobberknoll/app/shared/ctx.test.ts
@@ -1,0 +1,16 @@
+import { assert, assertNotEquals } from "@std/assert";
+import { isSome, uuid } from "../../core/shared/mod.ts";
+import { newCtx } from "./ctx.ts";
+
+Deno.test("newCtx should return a context with a valid UUID", () => {
+  const ctx = newCtx();
+
+  assert(isSome(uuid(ctx.requestId)));
+});
+
+Deno.test("newCtx should produce different UUIDs on different calls", () => {
+  const ctx1 = newCtx();
+  const ctx2 = newCtx();
+
+  assertNotEquals(ctx1.requestId, ctx2.requestId);
+});

--- a/implementation/jobberknoll/app/shared/ctx.ts
+++ b/implementation/jobberknoll/app/shared/ctx.ts
@@ -1,0 +1,5 @@
+import { type UUID, uuid } from "@jobberknoll/core/shared";
+
+export type Ctx = { requestId: UUID };
+
+export const newCtx: () => Ctx = () => ({ requestId: uuid() });

--- a/implementation/jobberknoll/app/shared/env.test.ts
+++ b/implementation/jobberknoll/app/shared/env.test.ts
@@ -1,0 +1,43 @@
+import { TestLogger } from "@jobberknoll/infra";
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import z from "zod";
+import { envReader, logEnvironment } from "./env.ts";
+
+const TestSchema = z.coerce.number();
+
+Deno.test("envReader should parse valid environment variables", () => {
+  const reader = envReader("TEST", TestSchema);
+
+  const value = reader(() => "123");
+
+  assertEquals(value, 123);
+});
+
+Deno.test("envReader should throw an error for missing environment variables", () => {
+  const reader = envReader("TEST", TestSchema);
+
+  assertThrows(() => reader(() => undefined));
+});
+
+Deno.test("envReader should throw an error for invalid environment variables", () => {
+  const reader = envReader("TEST", TestSchema);
+
+  assertThrows(() => reader(() => "abc"));
+});
+
+Deno.test("logEnvironment should log the environment", () => {
+  const logger = new TestLogger();
+  const getter = (key: string) => ({
+    PROD: undefined,
+    SERVER_PORT: "123",
+    DATABASE_URL: "postgres://example",
+  }[key]);
+
+  logEnvironment(logger, getter);
+
+  assert(logger.matches("env", {
+    prod: false,
+    serverPort: 123,
+    databaseUrl: "postgres://example",
+  }, null));
+});

--- a/implementation/jobberknoll/app/shared/mod.ts
+++ b/implementation/jobberknoll/app/shared/mod.ts
@@ -1,3 +1,4 @@
+export * from "./ctx.ts";
 export * from "./env.ts";
 export * from "./health.ts";
 export * from "./roles.ts";

--- a/implementation/jobberknoll/app/use-cases/create-account-use-case.test.ts
+++ b/implementation/jobberknoll/app/use-cases/create-account-use-case.test.ts
@@ -1,1 +1,77 @@
-// TODO: Implement missing tests
+import { accountMock, isErr, isOk, isSome, uuid } from "@jobberknoll/core/shared";
+import { MemoryAccountRepo, TestLogger } from "@jobberknoll/infra";
+import { assert, assertEquals } from "@std/assert";
+import { newCtx } from "~/shared/mod.ts";
+import { CreateAccountUseCase } from "./create-account-use-case.ts";
+
+function setup() {
+  const logger = new TestLogger();
+  const accountRepo = new MemoryAccountRepo(logger);
+  const createAccount = new CreateAccountUseCase(logger, accountRepo);
+  return { logger, accountRepo, createAccount };
+}
+
+const createAccountReq = {
+  type: "driver" as const,
+  fullName: "John Doe",
+  email: "john.doe@example.com",
+  password: "password",
+};
+
+Deno.test("CreateAccountUseCase should return a new account if the email is valid", async () => {
+  const { createAccount } = setup();
+
+  const result = await createAccount.invoke(newCtx(), createAccountReq);
+
+  assert(isOk(result));
+  const created = result.value;
+  assert(isSome(uuid(created.id)));
+  assertEquals(created.type, createAccountReq.type);
+  assertEquals(created.fullName, createAccountReq.fullName);
+  assertEquals(created.email, createAccountReq.email);
+  assert("hashedPassword" in created);
+});
+
+Deno.test("CreateAccountUseCase should add the account to the database if the email is valid", async () => {
+  const { accountRepo, createAccount } = setup();
+
+  const result = await createAccount.invoke(newCtx(), createAccountReq);
+
+  assert(isOk(result));
+
+  const created = result.value;
+  const found = await accountRepo.getAccountById(newCtx(), created.id);
+
+  assert(isOk(found));
+  assertEquals(found.value, created);
+});
+
+Deno.test("CreateAccountUseCase should audit the account creation if the email is valid", async () => {
+  const { logger, createAccount } = setup();
+
+  await createAccount.invoke(newCtx(), createAccountReq);
+
+  assert(logger.matches("audit log - AccountCreated"));
+});
+
+Deno.test("CreateAccountUseCase should return invalid-account-data if the email is taken", async () => {
+  const { accountRepo, createAccount } = setup();
+  await accountRepo.createAccount(newCtx(), { ...accountMock, email: createAccountReq.email });
+
+  const result = await createAccount.invoke(newCtx(), createAccountReq);
+
+  assert(isErr(result));
+});
+
+Deno.test("CreateAccountUseCase should not audit the account creation if the email is taken", async () => {
+  const { logger, accountRepo, createAccount } = setup();
+  await accountRepo.createAccount(newCtx(), { ...accountMock, email: createAccountReq.email });
+
+  await createAccount.invoke(newCtx(), createAccountReq);
+
+  assert(!logger.matches("audit log - AccountCreated"));
+});
+
+Deno.test.ignore("CreateAccountUseCase should hash the password", async () => {
+  // TODO: hash password
+});

--- a/implementation/jobberknoll/app/use-cases/create-account-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/create-account-use-case.ts
@@ -1,6 +1,7 @@
 import { type Account, invalidAccountData, type InvalidAccountDataError } from "@jobberknoll/core/domain";
 import { err, ok, type Result, uuid } from "@jobberknoll/core/shared";
 import type { AccountRepo, Logger } from "~/interfaces/mod.ts";
+import type { Ctx } from "~/shared/ctx.ts";
 import { UseCase } from "./use-case.ts";
 
 type CreateAccountReq = {
@@ -11,12 +12,12 @@ type CreateAccountReq = {
 };
 
 export class CreateAccountUseCase extends UseCase<CreateAccountReq, Account, InvalidAccountDataError> {
-  public constructor(private readonly accountRepo: AccountRepo, logger: Logger) {
+  public constructor(logger: Logger, private readonly accountRepo: AccountRepo) {
     super(logger);
   }
 
-  protected async handle(req: CreateAccountReq): Promise<Result<Account, InvalidAccountDataError>> {
-    if (await this.accountRepo.isEmailTaken(req.email)) {
+  protected async handle(ctx: Ctx, req: CreateAccountReq): Promise<Result<Account, InvalidAccountDataError>> {
+    if (await this.accountRepo.isEmailTaken(ctx, req.email)) {
       return err(invalidAccountData("email"));
     }
 
@@ -29,7 +30,7 @@ export class CreateAccountUseCase extends UseCase<CreateAccountReq, Account, Inv
       lastModified: Math.floor(Date.now() / 1000),
     };
 
-    await this.accountRepo.createAccount(account);
+    await this.accountRepo.createAccount(ctx, account);
 
     return ok(account);
   }

--- a/implementation/jobberknoll/app/use-cases/create-account-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/create-account-use-case.ts
@@ -31,6 +31,7 @@ export class CreateAccountUseCase extends UseCase<CreateAccountReq, Account, Inv
     };
 
     await this.accountRepo.createAccount(ctx, account);
+    this.audit("AccountCreated", account.id);
 
     return ok(account);
   }

--- a/implementation/jobberknoll/app/use-cases/delete-account-use-case.test.ts
+++ b/implementation/jobberknoll/app/use-cases/delete-account-use-case.test.ts
@@ -1,1 +1,56 @@
-// TODO: Implement missing tests
+import { accountMock, isErr, isOk } from "@jobberknoll/core/shared";
+import { MemoryAccountRepo, TestLogger } from "@jobberknoll/infra";
+import { assert } from "@std/assert";
+import { newCtx } from "~/shared/mod.ts";
+import { DeleteAccountUseCase } from "./delete-account-use-case.ts";
+
+function setup() {
+  const logger = new TestLogger();
+  const accountRepo = new MemoryAccountRepo(logger);
+  const deleteAccount = new DeleteAccountUseCase(logger, accountRepo);
+  return { logger, accountRepo, deleteAccount };
+}
+
+Deno.test("DeleteAccountUseCase should return an ok result if the account existed", async () => {
+  const { accountRepo, deleteAccount } = setup();
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  const result = await deleteAccount.invoke(newCtx(), { accountId: accountMock.id });
+
+  assert(isOk(result));
+});
+
+Deno.test("DeleteAccountUseCase should delete the account from the repository if it existed", async () => {
+  const { accountRepo, deleteAccount } = setup();
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  await deleteAccount.invoke(newCtx(), { accountId: accountMock.id });
+  const found = await accountRepo.getAccountById(newCtx(), accountMock.id);
+
+  assert(isErr(found));
+});
+
+Deno.test("DeleteAccountUseCase should audit the deletion if the account existed", async () => {
+  const { logger, accountRepo, deleteAccount } = setup();
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  await deleteAccount.invoke(newCtx(), { accountId: accountMock.id });
+
+  assert(logger.matches("audit log - AccountDeleted"));
+});
+
+Deno.test("DeleteAccountUseCase should return account-not-found if the account did not exist", async () => {
+  const { deleteAccount } = setup();
+
+  const result = await deleteAccount.invoke(newCtx(), { accountId: accountMock.id });
+
+  assert(isErr(result));
+});
+
+Deno.test("DeleteAccountUseCase should not audit the deletion if the account did not exist", async () => {
+  const { logger, deleteAccount } = setup();
+
+  await deleteAccount.invoke(newCtx(), { accountId: accountMock.id });
+
+  assert(!logger.matches("audit log - AccountDeleted"));
+});

--- a/implementation/jobberknoll/app/use-cases/delete-account-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/delete-account-use-case.ts
@@ -1,17 +1,18 @@
 import type { AccountNotFoundError } from "@jobberknoll/core/domain";
 import { err, isNone, ok, type Result, type UUID } from "@jobberknoll/core/shared";
 import type { AccountRepo, Logger } from "~/interfaces/mod.ts";
+import type { Ctx } from "~/shared/ctx.ts";
 import { UseCase } from "./use-case.ts";
 
 type DeleteAccountReq = { accountId: UUID };
 
 export class DeleteAccountUseCase extends UseCase<DeleteAccountReq, null, AccountNotFoundError> {
-  public constructor(private readonly accountRepo: AccountRepo, logger: Logger) {
+  public constructor(logger: Logger, private readonly accountRepo: AccountRepo) {
     super(logger);
   }
 
-  protected async handle(req: DeleteAccountReq): Promise<Result<null, AccountNotFoundError>> {
-    const error = await this.accountRepo.deleteAccount(req.accountId);
+  protected async handle(ctx: Ctx, req: DeleteAccountReq): Promise<Result<null, AccountNotFoundError>> {
+    const error = await this.accountRepo.deleteAccount(ctx, req.accountId);
     return isNone(error) ? ok(null) : err(error.value);
   }
 }

--- a/implementation/jobberknoll/app/use-cases/delete-account-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/delete-account-use-case.ts
@@ -1,5 +1,5 @@
 import type { AccountNotFoundError } from "@jobberknoll/core/domain";
-import { err, isNone, ok, type Result, type UUID } from "@jobberknoll/core/shared";
+import { err, isSome, ok, type Result, type UUID } from "@jobberknoll/core/shared";
 import type { AccountRepo, Logger } from "~/interfaces/mod.ts";
 import type { Ctx } from "~/shared/ctx.ts";
 import { UseCase } from "./use-case.ts";
@@ -13,6 +13,8 @@ export class DeleteAccountUseCase extends UseCase<DeleteAccountReq, null, Accoun
 
   protected async handle(ctx: Ctx, req: DeleteAccountReq): Promise<Result<null, AccountNotFoundError>> {
     const error = await this.accountRepo.deleteAccount(ctx, req.accountId);
-    return isNone(error) ? ok(null) : err(error.value);
+    if (isSome(error)) return err(error.value);
+    this.audit("AccountDeleted", req.accountId);
+    return ok(null);
   }
 }

--- a/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.test.ts
+++ b/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.test.ts
@@ -1,15 +1,16 @@
 import { accountMock, isErr, ok, uuid } from "@jobberknoll/core/shared";
 import { MemoryAccountRepo, TestLogger } from "@jobberknoll/infra";
 import { assert, assertEquals } from "@std/assert";
+import { newCtx } from "~/shared/ctx.ts";
 import { GetAccountByIdUseCase } from "./get-account-by-id-use-case.ts";
 
 Deno.test("GetAccountByIdUseCase should return an account if it exists", async () => {
   const logger = new TestLogger();
   const accountRepo = new MemoryAccountRepo(logger);
-  await accountRepo.createAccount(accountMock);
-  const useCase = new GetAccountByIdUseCase(accountRepo, logger);
+  await accountRepo.createAccount(newCtx(), accountMock);
+  const useCase = new GetAccountByIdUseCase(logger, accountRepo);
 
-  const result = await useCase.invoke({ accountId: accountMock.id }, uuid());
+  const result = await useCase.invoke(newCtx(), { accountId: accountMock.id });
 
   assertEquals(result, ok(accountMock));
 });
@@ -18,9 +19,9 @@ Deno.test("GetAccountByIdUseCase should return account-not-found if the account 
   const id = uuid();
   const logger = new TestLogger();
   const accountRepo = new MemoryAccountRepo(logger);
-  const useCase = new GetAccountByIdUseCase(accountRepo, logger);
+  const useCase = new GetAccountByIdUseCase(logger, accountRepo);
 
-  const result = await useCase.invoke({ accountId: id }, uuid());
+  const result = await useCase.invoke(newCtx(), { accountId: id });
 
   assert(isErr(result));
 });

--- a/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.test.ts
+++ b/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.test.ts
@@ -4,24 +4,26 @@ import { assert, assertEquals } from "@std/assert";
 import { newCtx } from "~/shared/ctx.ts";
 import { GetAccountByIdUseCase } from "./get-account-by-id-use-case.ts";
 
-Deno.test("GetAccountByIdUseCase should return an account if it exists", async () => {
+function setup() {
   const logger = new TestLogger();
   const accountRepo = new MemoryAccountRepo(logger);
-  await accountRepo.createAccount(newCtx(), accountMock);
-  const useCase = new GetAccountByIdUseCase(logger, accountRepo);
+  const getAccountById = new GetAccountByIdUseCase(logger, accountRepo);
+  return { logger, accountRepo, getAccountById };
+}
 
-  const result = await useCase.invoke(newCtx(), { accountId: accountMock.id });
+Deno.test("GetAccountByIdUseCase should return an account if it exists", async () => {
+  const { accountRepo, getAccountById } = setup();
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  const result = await getAccountById.invoke(newCtx(), { accountId: accountMock.id });
 
   assertEquals(result, ok(accountMock));
 });
 
 Deno.test("GetAccountByIdUseCase should return account-not-found if the account does not exist", async () => {
-  const id = uuid();
-  const logger = new TestLogger();
-  const accountRepo = new MemoryAccountRepo(logger);
-  const useCase = new GetAccountByIdUseCase(logger, accountRepo);
+  const { getAccountById } = setup();
 
-  const result = await useCase.invoke(newCtx(), { accountId: id });
+  const result = await getAccountById.invoke(newCtx(), { accountId: uuid() });
 
   assert(isErr(result));
 });

--- a/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/get-account-by-id-use-case.ts
@@ -1,16 +1,17 @@
 import type { Account, AccountNotFoundError } from "@jobberknoll/core/domain";
 import type { Result, UUID } from "@jobberknoll/core/shared";
 import type { AccountRepo, Logger } from "~/interfaces/mod.ts";
+import type { Ctx } from "~/shared/ctx.ts";
 import { UseCase } from "./use-case.ts";
 
 type GetAccountByIdReq = { accountId: UUID };
 
 export class GetAccountByIdUseCase extends UseCase<GetAccountByIdReq, Account, AccountNotFoundError> {
-  public constructor(private readonly accountRepo: AccountRepo, logger: Logger) {
+  public constructor(logger: Logger, private readonly accountRepo: AccountRepo) {
     super(logger);
   }
 
-  protected async handle({ accountId }: GetAccountByIdReq): Promise<Result<Account, AccountNotFoundError>> {
-    return await this.accountRepo.getAccountById(accountId);
+  protected async handle(ctx: Ctx, { accountId }: GetAccountByIdReq): Promise<Result<Account, AccountNotFoundError>> {
+    return await this.accountRepo.getAccountById(ctx, accountId);
   }
 }

--- a/implementation/jobberknoll/app/use-cases/get-health-use-case.test.ts
+++ b/implementation/jobberknoll/app/use-cases/get-health-use-case.test.ts
@@ -1,1 +1,16 @@
-// TODO: Implement missing tests
+import { isOk } from "@jobberknoll/core/shared";
+import { TestLogger } from "@jobberknoll/infra";
+import { assert } from "@std/assert/assert";
+import { assertEquals } from "@std/assert/equals";
+import { newCtx } from "~/mod.ts";
+import { GetHealthUseCase } from "./get-health-use-case.ts";
+
+Deno.test("GetHealthUseCase should return the health status", async () => {
+  const logger = new TestLogger();
+  const getHealth = new GetHealthUseCase(logger);
+
+  const result = await getHealth.invoke(newCtx(), null);
+
+  assert(isOk(result));
+  assertEquals(result.value, { status: "UP" });
+});

--- a/implementation/jobberknoll/app/use-cases/get-health-use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/get-health-use-case.ts
@@ -1,5 +1,6 @@
 import { ok, type Result } from "@jobberknoll/core/shared";
 import type { Logger } from "~/interfaces/mod.ts";
+import type { Ctx } from "~/shared/ctx.ts";
 import type { ServiceHealth } from "~/shared/mod.ts";
 import { UseCase } from "./use-case.ts";
 
@@ -8,7 +9,7 @@ export class GetHealthUseCase extends UseCase<null, ServiceHealth, never> {
     super(logger);
   }
 
-  protected handle(_: null): Promise<Result<ServiceHealth, never>> {
+  protected handle(_ctx: Ctx, _req: null): Promise<Result<ServiceHealth, never>> {
     // TODO: Fetch infrastructure health.
     return Promise.resolve(ok({ status: "UP" }));
   }

--- a/implementation/jobberknoll/app/use-cases/use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/use-case.ts
@@ -1,19 +1,12 @@
-import { isOk, type Result, type UUID } from "@jobberknoll/core/shared";
+import type { Result } from "@jobberknoll/core/shared";
 import type { Logger } from "~/interfaces/mod.ts";
+import type { Ctx } from "~/shared/ctx.ts";
 
 export abstract class UseCase<Req, Res, Err> {
-  protected constructor(private readonly logger: Logger) {}
-
-  public async invoke(req: Req, requestId: UUID): Promise<Result<Res, Err>> {
-    const method = `${this.constructor.name}#invoke`;
-    this.logger.debug(requestId, `${method} - start`, { req: req });
-
-    const res = await this.handle(req);
-
-    const tags = isOk(res) ? { ok: res.value } : { err: res.value };
-    this.logger.debug(requestId, `${method} - end`, tags);
-    return res;
+  protected constructor(logger: Logger) {
+    this.invoke = logger.propagate(this, this.handle);
   }
 
-  protected abstract handle(req: Req): Promise<Result<Res, Err>>;
+  protected abstract handle(ctx: Ctx, req: Req): Promise<Result<Res, Err>>;
+  public invoke: (ctx: Ctx, req: Req) => Promise<Result<Res, Err>>;
 }

--- a/implementation/jobberknoll/app/use-cases/use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/use-case.ts
@@ -10,7 +10,7 @@ export abstract class UseCase<Req, Res, Err> {
   protected abstract handle(ctx: Ctx, req: Req): Promise<Result<Res, Err>>;
   public invoke: (ctx: Ctx, req: Req) => Promise<Result<Res, Err>>;
 
-  protected audit(event: string, subject: UUID) {
-    this.logger.info(null, `audit log - ${event}`, { subject });
+  protected audit(eventKind: string, subject: UUID) {
+    this.logger.info(null, `audit log - ${eventKind}`, { subject });
   }
 }

--- a/implementation/jobberknoll/app/use-cases/use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/use-case.ts
@@ -1,12 +1,16 @@
-import type { Result } from "@jobberknoll/core/shared";
+import type { Result, UUID } from "@jobberknoll/core/shared";
 import type { Logger } from "~/interfaces/mod.ts";
 import type { Ctx } from "~/shared/ctx.ts";
 
 export abstract class UseCase<Req, Res, Err> {
-  protected constructor(logger: Logger) {
+  protected constructor(private readonly logger: Logger) {
     this.invoke = logger.propagate(this, this.handle);
   }
 
   protected abstract handle(ctx: Ctx, req: Req): Promise<Result<Res, Err>>;
   public invoke: (ctx: Ctx, req: Req) => Promise<Result<Res, Err>>;
+
+  protected audit(event: string, subject: UUID) {
+    this.logger.info(null, `audit log - ${event}`, { subject });
+  }
 }

--- a/implementation/jobberknoll/app/use-cases/use-case.ts
+++ b/implementation/jobberknoll/app/use-cases/use-case.ts
@@ -8,7 +8,7 @@ export abstract class UseCase<Req, Res, Err> {
   }
 
   protected abstract handle(ctx: Ctx, req: Req): Promise<Result<Res, Err>>;
-  public invoke: (ctx: Ctx, req: Req) => Promise<Result<Res, Err>>;
+  public readonly invoke: (ctx: Ctx, req: Req) => Promise<Result<Res, Err>>;
 
   protected audit(eventKind: string, subject: UUID) {
     this.logger.info(null, `audit log - ${eventKind}`, { subject });

--- a/implementation/jobberknoll/deno.json
+++ b/implementation/jobberknoll/deno.json
@@ -3,7 +3,7 @@
   "workspace": ["api", "app", "core", "infra"],
   "tasks": {
     "dev": "deno run --allow-net --allow-env main.ts",
-    "test": "deno test --coverage && deno coverage",
+    "test": "deno test --coverage && deno coverage --html && deno coverage",
     "compile": "deno compile --allow-net --allow-env --output jobberknoll main.ts"
   },
   "fmt": {

--- a/implementation/jobberknoll/deno.json
+++ b/implementation/jobberknoll/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.6.0",
   "workspace": ["api", "app", "core", "infra"],
   "tasks": {
     "dev": "deno run --allow-net --allow-env main.ts",

--- a/implementation/jobberknoll/deno.json
+++ b/implementation/jobberknoll/deno.json
@@ -3,6 +3,7 @@
   "workspace": ["api", "app", "core", "infra"],
   "tasks": {
     "dev": "deno run --allow-net --allow-env main.ts",
+    "test": "deno test --coverage && deno coverage",
     "compile": "deno compile --allow-net --allow-env --output jobberknoll main.ts"
   },
   "fmt": {

--- a/implementation/jobberknoll/infra/account-repo/memory-account-repo.test.ts
+++ b/implementation/jobberknoll/infra/account-repo/memory-account-repo.test.ts
@@ -1,13 +1,14 @@
 import { accountMock, isErr, ok, uuid } from "@jobberknoll/core/shared";
 import { assert, assertEquals } from "@std/assert";
+import { newCtx } from "../../app/shared/ctx.ts";
 import { TestLogger } from "../logger/mod.ts";
 import { MemoryAccountRepo } from "./memory-account-repo.ts";
 
 Deno.test("getAccountById should return an account if it exists", async () => {
   const accountRepo = new MemoryAccountRepo(new TestLogger());
-  await accountRepo.createAccount(accountMock);
+  await accountRepo.createAccount(newCtx(), accountMock);
 
-  const result = await accountRepo.getAccountById(accountMock.id);
+  const result = await accountRepo.getAccountById(newCtx(), accountMock.id);
 
   assertEquals(result, ok(accountMock));
 });
@@ -16,7 +17,7 @@ Deno.test("getAccountById should return account-not-found if the account does no
   const id = uuid();
   const accountRepo = new MemoryAccountRepo(new TestLogger());
 
-  const result = await accountRepo.getAccountById(id);
+  const result = await accountRepo.getAccountById(newCtx(), id);
 
   assert(isErr(result));
 });

--- a/implementation/jobberknoll/infra/account-repo/memory-account-repo.test.ts
+++ b/implementation/jobberknoll/infra/account-repo/memory-account-repo.test.ts
@@ -1,8 +1,48 @@
-import { accountMock, isErr, ok, uuid } from "@jobberknoll/core/shared";
-import { assert, assertEquals } from "@std/assert";
-import { newCtx } from "../../app/shared/ctx.ts";
+import { newCtx } from "@jobberknoll/app";
+import { accountMock, isErr, isNone, ok, uuid } from "@jobberknoll/core/shared";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { TestLogger } from "../logger/mod.ts";
 import { MemoryAccountRepo } from "./memory-account-repo.ts";
+
+Deno.test("createAccount should add an account to the repo", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  const result = await accountRepo.getAccountById(newCtx(), accountMock.id);
+  assertEquals(result, ok(accountMock));
+});
+
+Deno.test("createAccount should reject on duplicate IDs", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+  await accountRepo.createAccount(newCtx(), { ...accountMock, email: "another@example.com" });
+
+  assertRejects(() => accountRepo.createAccount(newCtx(), accountMock));
+});
+
+Deno.test("createAccount should reject on duplicate emails", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+  await accountRepo.createAccount(newCtx(), { ...accountMock, id: uuid() });
+
+  assertRejects(() => accountRepo.createAccount(newCtx(), accountMock));
+});
+
+Deno.test("isEmailTaken should return true if the email is taken", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  const isTaken = await accountRepo.isEmailTaken(newCtx(), accountMock.email);
+
+  assert(isTaken);
+});
+
+Deno.test("isEmailTaken should return false if the email is not taken", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+
+  const isTaken = await accountRepo.isEmailTaken(newCtx(), accountMock.email);
+
+  assert(!isTaken);
+});
 
 Deno.test("getAccountById should return an account if it exists", async () => {
   const accountRepo = new MemoryAccountRepo(new TestLogger());
@@ -14,12 +54,36 @@ Deno.test("getAccountById should return an account if it exists", async () => {
 });
 
 Deno.test("getAccountById should return account-not-found if the account does not exist", async () => {
-  const id = uuid();
   const accountRepo = new MemoryAccountRepo(new TestLogger());
 
-  const result = await accountRepo.getAccountById(newCtx(), id);
+  const result = await accountRepo.getAccountById(newCtx(), uuid());
 
   assert(isErr(result));
 });
 
-// TODO: Implement missing tests
+Deno.test("deleteAccount should return none option if the account exists", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  const option = await accountRepo.deleteAccount(newCtx(), accountMock.id);
+
+  assert(isNone(option));
+});
+
+Deno.test("deleteAccount should remove the account from the repo if it exists", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+  await accountRepo.createAccount(newCtx(), accountMock);
+
+  await accountRepo.deleteAccount(newCtx(), accountMock.id);
+
+  const result = await accountRepo.getAccountById(newCtx(), accountMock.id);
+  assert(isErr(result));
+});
+
+Deno.test("deleteAccount should return some account-not-found if the account does not exist", async () => {
+  const accountRepo = new MemoryAccountRepo(new TestLogger());
+
+  const option = await accountRepo.deleteAccount(newCtx(), uuid());
+
+  assert(!isNone(option));
+});

--- a/implementation/jobberknoll/infra/account-repo/postgres-account-repo.ts
+++ b/implementation/jobberknoll/infra/account-repo/postgres-account-repo.ts
@@ -6,11 +6,11 @@ import { Pool } from "postgres";
 const POOL_SIZE = 8;
 
 export class PostgresAccountRepo extends AccountRepo {
-  private constructor(private readonly pool: Pool, logger: Logger) {
+  private constructor(logger: Logger, private readonly pool: Pool) {
     super(logger);
   }
 
-  public static async setup(connectionString: string, logger: Logger): Promise<AccountRepo> {
+  public static async setup(logger: Logger, connectionString: string): Promise<AccountRepo> {
     const pool = new Pool(connectionString, POOL_SIZE, true);
 
     using client = await pool.connect();
@@ -32,7 +32,7 @@ export class PostgresAccountRepo extends AccountRepo {
         CHECK (phone_number IS NULL OR type = 'passenger')
       )`;
 
-    return new PostgresAccountRepo(pool, logger);
+    return new PostgresAccountRepo(logger, pool);
   }
 
   protected async handleCreateAccount(account: Account): Promise<void> {

--- a/implementation/jobberknoll/infra/logger/test-logger.test.ts
+++ b/implementation/jobberknoll/infra/logger/test-logger.test.ts
@@ -1,0 +1,52 @@
+import { uuid } from "@jobberknoll/core/shared";
+import { assert } from "@std/assert";
+import { TestLogger } from "./test-logger.ts";
+
+Deno.test("matches should return true if the logger has logged a given event", () => {
+  const logger = new TestLogger();
+
+  logger.info(null, "event");
+
+  assert(logger.matches("event"));
+});
+
+Deno.test("matches should return true if the correct tags have been logged", () => {
+  const logger = new TestLogger();
+
+  logger.info(null, "event", { key: "value", deep: [1, 2], extra: "extra" });
+
+  assert(logger.matches("event", { key: "value", deep: [1, 2] }));
+});
+
+Deno.test("matches should return true if the correct requestId has been logged", () => {
+  const logger = new TestLogger();
+  const requestId = uuid();
+
+  logger.info(requestId, "event");
+
+  assert(logger.matches("event", {}, requestId));
+});
+
+Deno.test("matches should return false if the logger has not logged a given event", () => {
+  const logger = new TestLogger();
+
+  logger.info(null, "event");
+
+  assert(!logger.matches("other"));
+});
+
+Deno.test("matches should return false if the incorrect tags have been logged", () => {
+  const logger = new TestLogger();
+
+  logger.info(null, "event", { key: "value", deep: [1, 2] });
+
+  assert(!logger.matches("event", { key: "value", deep: [3, 4] }));
+});
+
+Deno.test("matches should return false if the incorrect requestId has been logged", () => {
+  const logger = new TestLogger();
+
+  logger.info(uuid(), "event");
+
+  assert(!logger.matches("event", {}, uuid()));
+});

--- a/implementation/jobberknoll/infra/logger/test-logger.ts
+++ b/implementation/jobberknoll/infra/logger/test-logger.ts
@@ -1,9 +1,22 @@
 import { type LogData, Logger } from "@jobberknoll/app";
 
 export class TestLogger extends Logger {
+  private readonly logs: LogData[] = [];
+
   protected readonly level = "debug";
 
-  protected handle(_data: LogData) {
-    // TODO: Implement to use in tests
+  protected handle(data: LogData) {
+    this.logs.push(data);
+  }
+
+  public matches(event: string, tags: Record<string, unknown> = {}): boolean {
+    return this.logs.some((log) => {
+      if (log.event !== event) return false;
+      for (const [key, value] of Object.entries(tags)) {
+        if (!(key in log.tags)) return false;
+        if (log.tags[key] !== value) return false;
+      }
+      return true;
+    });
   }
 }

--- a/implementation/jobberknoll/infra/logger/test-logger.ts
+++ b/implementation/jobberknoll/infra/logger/test-logger.ts
@@ -1,4 +1,5 @@
 import { type LogData, Logger } from "@jobberknoll/app";
+import type { UUID } from "@jobberknoll/core/shared";
 
 export class TestLogger extends Logger {
   private readonly logs: LogData[] = [];
@@ -9,13 +10,14 @@ export class TestLogger extends Logger {
     this.logs.push(data);
   }
 
-  public matches(event: string, tags: Record<string, unknown> = {}): boolean {
+  public matches(event: string, tags: Record<string, unknown> = {}, requestId?: UUID | null): boolean {
     return this.logs.some((log) => {
       if (log.event !== event) return false;
       for (const [key, value] of Object.entries(tags)) {
         if (!(key in log.tags)) return false;
-        if (log.tags[key] !== value) return false;
+        if (JSON.stringify(log.tags[key]) !== JSON.stringify(value)) return false;
       }
+      if (requestId !== undefined && log.requestId !== requestId) return false;
       return true;
     });
   }

--- a/implementation/jobberknoll/main.ts
+++ b/implementation/jobberknoll/main.ts
@@ -2,7 +2,7 @@ import { envProd, envServerPort, logEnvironment } from "./app/mod.ts";
 import { setupDev, setupProd } from "./setup.ts";
 
 if (import.meta.main) {
-  const { api, logger } = envProd() ? await setupProd() : setupDev();
+  const { api, logger } = envProd() ? await setupProd() : await setupDev();
 
   logEnvironment(logger);
 

--- a/implementation/jobberknoll/setup.ts
+++ b/implementation/jobberknoll/setup.ts
@@ -2,25 +2,29 @@ import { buildApi } from "@jobberknoll/api";
 import { AccountRepo, buildService, envDatabaseUrl, Logger } from "@jobberknoll/app";
 import { DevLogger, MemoryAccountRepo, PostgresAccountRepo, ProdLogger, TestLogger } from "@jobberknoll/infra";
 
-// TODO: Refactor this to inject Logger to other infra classes
+type Factory<T> = (logger: Logger) => T | Promise<T>;
 
-function setup(accountRepo: AccountRepo, logger: Logger) {
-  const service = buildService(accountRepo, logger);
-  const api = buildApi(service, logger);
+async function setup(logger: Logger, accountRepoFactory: Factory<AccountRepo>) {
+  const accountRepo = await accountRepoFactory(logger);
+  const service = buildService(logger, accountRepo);
+  const api = buildApi(logger, service);
   return { api, accountRepo, logger };
 }
 
-export const setupDev = () => {
-  const logger = new DevLogger();
-  return setup(new MemoryAccountRepo(logger), logger);
-};
+export const setupDev = () =>
+  setup(
+    new DevLogger(),
+    (l) => new MemoryAccountRepo(l),
+  );
 
-export const setupProd = async () => {
-  const logger = new ProdLogger();
-  return setup(await PostgresAccountRepo.setup(envDatabaseUrl(), logger), logger);
-};
+export const setupProd = () =>
+  setup(
+    new ProdLogger(),
+    async (l) => await PostgresAccountRepo.setup(l, envDatabaseUrl()),
+  );
 
-export const setupTest = () => {
-  const logger = new TestLogger();
-  return setup(new MemoryAccountRepo(logger), logger);
-};
+export const setupTest = () =>
+  setup(
+    new TestLogger(),
+    (l) => new MemoryAccountRepo(l),
+  );

--- a/implementation/jobberknoll/tests/create-account-e2e.test.ts
+++ b/implementation/jobberknoll/tests/create-account-e2e.test.ts
@@ -1,5 +1,6 @@
 import { accountMock, isSome, uuid } from "@jobberknoll/core/shared";
 import { assert, assertEquals, assertObjectMatch } from "@std/assert";
+import { newCtx } from "../app/shared/ctx.ts";
 import { setupTest } from "../setup.ts";
 
 const correctHeaders = {
@@ -18,7 +19,7 @@ const correctBody = {
 };
 
 Deno.test("POST /ext/v1/accounts should create an account if data is valid", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts", {
     method: "POST",
@@ -35,7 +36,7 @@ Deno.test("POST /ext/v1/accounts should create an account if data is valid", asy
 });
 
 Deno.test("POST /ext/v1/accounts not leak private fields", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts", {
     method: "POST",
@@ -49,7 +50,7 @@ Deno.test("POST /ext/v1/accounts not leak private fields", async () => {
 });
 
 Deno.test("POST /ext/v1/accounts should return user-unauthorized if user is not an admin", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts", {
     method: "POST",
@@ -71,7 +72,7 @@ for (
   ]
 ) {
   Deno.test(`POST /ext/v1/accounts should return schema-mismatch if ${field} is invalid`, async () => {
-    const { api } = setupTest();
+    const { api } = await setupTest();
 
     const response = await api.request("/ext/v1/accounts", {
       method: "POST",
@@ -86,7 +87,7 @@ for (
 }
 
 Deno.test("POST /ext/v1/accounts should return schema-mismatch if body has wrong content-type", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts", {
     method: "POST",
@@ -100,8 +101,8 @@ Deno.test("POST /ext/v1/accounts should return schema-mismatch if body has wrong
 });
 
 Deno.test("POST /ext/v1/accounts should return invalid-account-data if the email is already taken", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount({ ...accountMock, email: "taken-email@example.com" });
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), { ...accountMock, email: "taken-email@example.com" });
 
   const response = await api.request("/ext/v1/accounts", {
     method: "POST",
@@ -115,7 +116,7 @@ Deno.test("POST /ext/v1/accounts should return invalid-account-data if the email
 });
 
 Deno.test("POST /ext/v1/accounts should create an account fetchable from GET /ext/v1/accounts/{id}", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const createResponse = await api.request("/ext/v1/accounts", {
     method: "POST",

--- a/implementation/jobberknoll/tests/delete-account-e2e.test.ts
+++ b/implementation/jobberknoll/tests/delete-account-e2e.test.ts
@@ -1,5 +1,6 @@
 import { accountMock, uuid } from "@jobberknoll/core/shared";
 import { assertEquals } from "@std/assert/equals";
+import { newCtx } from "../app/shared/ctx.ts";
 import { setupTest } from "../setup.ts";
 
 const correctHeaders = {
@@ -10,8 +11,8 @@ const correctHeaders = {
 };
 
 Deno.test("DELETE /ext/v1/accounts/{id} should delete the account if it exists", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(
     `/ext/v1/accounts/${accountMock.id}`,
@@ -24,8 +25,8 @@ Deno.test("DELETE /ext/v1/accounts/{id} should delete the account if it exists",
 });
 
 Deno.test("DELETE /ext/v1/accounts/{id} should return user-unauthorized if user is not an admin", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(`/ext/v1/accounts/${accountMock.id}`, {
     method: "DELETE",
@@ -38,7 +39,7 @@ Deno.test("DELETE /ext/v1/accounts/{id} should return user-unauthorized if user 
 });
 
 Deno.test("DELETE /ext/v1/accounts/{id} should return schema-mismatch if the account id is not an UUID", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts/123", { method: "DELETE", headers: correctHeaders });
   const body = await response.json();
@@ -48,7 +49,7 @@ Deno.test("DELETE /ext/v1/accounts/{id} should return schema-mismatch if the acc
 });
 
 Deno.test("DELETE /ext/v1/accounts/{id} should return account-not-found if the account does not exist", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request(`/ext/v1/accounts/${uuid()}`, { method: "DELETE", headers: correctHeaders });
   const body = await response.json();
@@ -58,8 +59,8 @@ Deno.test("DELETE /ext/v1/accounts/{id} should return account-not-found if the a
 });
 
 Deno.test("DELETE /ext/v1/accounts/{id} should make the account unfetchable from GET /ext/v1/accounts/{id}", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   await api.request(`/ext/v1/accounts/${accountMock.id}`, { method: "DELETE", headers: correctHeaders });
 

--- a/implementation/jobberknoll/tests/docs-e2e.test.ts
+++ b/implementation/jobberknoll/tests/docs-e2e.test.ts
@@ -3,7 +3,7 @@ import { setupTest } from "../setup.ts";
 
 for (const scope of ["int", "ext"]) {
   Deno.test(`GET /${scope}/v1/docs should return an index of docs`, async () => {
-    const { api } = setupTest();
+    const { api } = await setupTest();
 
     const response = await api.request(`/${scope}/v1/docs`);
     const body = await response.json();
@@ -15,7 +15,7 @@ for (const scope of ["int", "ext"]) {
   });
 
   Deno.test(`GET /${scope}/v1/docs/openapi.json should return the OpenAPI spec`, async () => {
-    const { api } = setupTest();
+    const { api } = await setupTest();
 
     const response = await api.request(`/${scope}/v1/docs/openapi.json`);
     const body = await response.json();
@@ -26,7 +26,7 @@ for (const scope of ["int", "ext"]) {
 
   for (const ui of ["swagger", "scalar"]) {
     Deno.test(`GET /${scope}/v1/docs/${ui} should be available`, async () => {
-      const { api } = setupTest();
+      const { api } = await setupTest();
 
       const response = await api.request(`/${scope}/v1/docs/${ui}`);
       const body = await response.text();

--- a/implementation/jobberknoll/tests/get-account-by-id-e2e.test.ts
+++ b/implementation/jobberknoll/tests/get-account-by-id-e2e.test.ts
@@ -1,10 +1,11 @@
 import { accountMock, uuid } from "@jobberknoll/core/shared";
 import { assert, assertEquals, assertObjectMatch } from "@std/assert";
+import { newCtx } from "../app/shared/ctx.ts";
 import { setupTest } from "../setup.ts";
 
 Deno.test("GET /int/v1/accounts/{id} should return an account if it exists", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(`/int/v1/accounts/${accountMock.id}`);
   const body = await response.json();
@@ -14,8 +15,8 @@ Deno.test("GET /int/v1/accounts/{id} should return an account if it exists", asy
 });
 
 Deno.test("GET /int/v1/accounts/{id} should not leak private fields", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(`/int/v1/accounts/${accountMock.id}`);
   const body = await response.json();
@@ -25,7 +26,7 @@ Deno.test("GET /int/v1/accounts/{id} should not leak private fields", async () =
 });
 
 Deno.test("GET /int/v1/accounts/{id} should return account-not-found if the account does not exist", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request(`/int/v1/accounts/${uuid()}`);
   const body = await response.json();
@@ -35,7 +36,7 @@ Deno.test("GET /int/v1/accounts/{id} should return account-not-found if the acco
 });
 
 Deno.test("GET /int/v1/accounts/{id} should return schema-mismatch if the account id is not an UUID", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/int/v1/accounts/123");
   const body = await response.json();
@@ -52,8 +53,8 @@ const correctHeaders = {
 };
 
 Deno.test("GET /ext/v1/accounts/{id} should return user-unauthorized if user is not an admin", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(`/ext/v1/accounts/${accountMock.id}`, {
     headers: { ...correctHeaders, "jp-user-role": "passenger" },
@@ -67,8 +68,8 @@ Deno.test("GET /ext/v1/accounts/{id} should return user-unauthorized if user is 
 Deno.test(
   "GET /ext/v1/accounts/{id} should return an account if it exists",
   async () => {
-    const { api, accountRepo } = setupTest();
-    await accountRepo.createAccount(accountMock);
+    const { api, accountRepo } = await setupTest();
+    await accountRepo.createAccount(newCtx(), accountMock);
 
     const response = await api.request(`/ext/v1/accounts/${accountMock.id}`, { headers: correctHeaders });
     const body = await response.json();
@@ -82,8 +83,8 @@ Deno.test(
 );
 
 Deno.test("GET /ext/v1/accounts/{id} should not leak private fields", async () => {
-  const { api, accountRepo } = setupTest();
-  await accountRepo.createAccount(accountMock);
+  const { api, accountRepo } = await setupTest();
+  await accountRepo.createAccount(newCtx(), accountMock);
 
   const response = await api.request(`/ext/v1/accounts/${accountMock.id}`, { headers: correctHeaders });
   const body = await response.json();
@@ -93,7 +94,7 @@ Deno.test("GET /ext/v1/accounts/{id} should not leak private fields", async () =
 });
 
 Deno.test("GET /ext/v1/accounts/{id} should return account-not-found if the account does not exist", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request(`/ext/v1/accounts/${uuid()}`, { headers: correctHeaders });
   const body = await response.json();
@@ -103,7 +104,7 @@ Deno.test("GET /ext/v1/accounts/{id} should return account-not-found if the acco
 });
 
 Deno.test("GET /ext/v1/accounts/{id} should return schema-mismatch if the account id is not an UUID", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/ext/v1/accounts/123", { headers: correctHeaders });
   const body = await response.json();

--- a/implementation/jobberknoll/tests/health-e2e.test.ts
+++ b/implementation/jobberknoll/tests/health-e2e.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "@std/assert";
 import { setupTest } from "../setup.ts";
 
 Deno.test("GET /int/v1/health should return the service health", async () => {
-  const { api } = setupTest();
+  const { api } = await setupTest();
 
   const response = await api.request("/int/v1/health");
   const body = await response.json();


### PR DESCRIPTION
1. **Problem:** The logging parameters `logger: Logger` and `requestId: UUID` were inconsequently passed around, sometimes they were the first argument, sometimes the last, sometimes in between. Two sensible answers would be to place them at the end or at the start.
    - **Solution:** Place all logging parameters at the start, this is more sensible, since a) variadic arguments can be only placed at the end so placing logger at the end would break it, b) when calling the function multiple time, placing common arguments at the start produces nicer aligment, c) that's what [opentracing](https://github.com/opentracing/opentracing-go#creating-a-span-given-an-existing-go-contextcontext) uses, d) all other services use the `Logger`, so passing it last would be weird. Thus **all `logger` and `requestId`** params should be first in function calls.
2. **Problem:** Request IDs passed around can be mistaken with other UUIDs and the request context can't be extended without major refactorings.
    - **Solution:** Replace all `requestId: UUID` arguments with `{ requestId }: Ctx` arguments.
3. **Problem:** Request IDs are not passed through to the `AccountRepo`, since `UseCase` trims request context. The code for instrumenting calls (in use cases and infra) is duplicated.
    - **Solution:** Create new `instrument` and `propagate` functions in `Logger`, then `propagate` use case handlers and `instrument` infra handlers.
4. **Problem:** Request context are not nicely extractable from HTTP requests.
    - **Solution:** Bind context to Hono's request to make it easy to access from all handlers.
5. **Problem:** Error DTO descriptions are duplicated all around, since DTO description and response descriptions are always the same.
    - **Solution:** Export response schemas for error DTOs to make the code more DRY. 
6. **Problem:** There is a ton of missing tests.
    - **Solution:** A bunch of new tests added, bringing the total to almost 150 tests with a ~90% coverage.