### PR TITLE
PR: Adjust libargon dylib opening

### DIFF
--- a/implementation/feather/Dockerfile
+++ b/implementation/feather/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:24.10 AS runner-base
 
 RUN apt-get -y update
-RUN apt-get -y install curl libargon2-1
+RUN apt-get -y install curl
 
 
 FROM denoland/deno:2.1.4 AS builder

--- a/implementation/feather/README.md
+++ b/implementation/feather/README.md
@@ -24,4 +24,3 @@ The service requires the following capabilities to be enabled:
 
 - `--allow-net` - required to host the web server
 - `--allow-env` - required to read config from environment variables
-- `--allow-ffi` - required for Argon2id

--- a/implementation/feather/deno.json
+++ b/implementation/feather/deno.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "tasks": {
-    "dev": "deno run --allow-net --allow-env --allow-ffi main.ts",
-    "compile": "deno compile --allow-net --allow-env --allow-ffi --output feather main.ts"
+    "dev": "deno run --allow-net --allow-env main.ts",
+    "compile": "deno compile --allow-net --allow-env --output feather main.ts"
   },
   "fmt": {
     "lineWidth": 120

--- a/implementation/jobberknoll/app/security/libargon2.ts
+++ b/implementation/jobberknoll/app/security/libargon2.ts
@@ -1,75 +1,85 @@
 // SAFETY: see ADR-003
 
-// SAFETY: even if the FFI fails, the code will error out, so the user will get a 5xx error, which is bad, but safe
-const libargon2 = Deno.dlopen(
-  "/usr/lib/x86_64-linux-gnu/libargon2.so.1", // sudo apt install libargon2-1
-  {
-    /*
-int argon2id_hash_encoded(const uint32_t t_cost,
-                          const uint32_t m_cost,
-                          const uint32_t parallelism,
-                          const void *pwd, const size_t pwdlen,
-                          const void *salt, const size_t saltlen,
-                          const size_t hashlen, char *encoded,
-                          const size_t encodedlen);
-    */
-    "argon2id_hash_encoded": {
-      parameters: ["u32", "u32", "u32", "buffer", "usize", "buffer", "usize", "usize", "buffer", "usize"],
-      result: "i32",
-    },
-    /*
-int argon2id_verify(const char *encoded, const void *pwd,
-                    const size_t pwdlen);
-    */
-    "argon2id_verify": {
-      parameters: ["buffer", "buffer", "usize"],
-      result: "i32",
-    },
-  },
-);
-
 const ENCODED_BUFFER_SIZE = 256;
 
 // SAFETY: TextEncoder and TextDecoder can be reused across calls (https://encoding.spec.whatwg.org/#interface-textencoder)
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-export function argon2idHashEncoded(
-  tCost: number,
-  mCost: number,
-  parallelism: number,
-  pwd: string,
-  saltBuffer: Uint8Array,
-  hashLen: number,
-): string {
-  const pwdBuffer = textEncoder.encode(pwd.normalize("NFKC"));
-  const encodedBuffer = new Uint8Array(ENCODED_BUFFER_SIZE);
-  const errorCode = libargon2.symbols.argon2id_hash_encoded(
-    tCost,
-    mCost,
-    parallelism,
-    pwdBuffer,
-    BigInt(pwdBuffer.length),
-    saltBuffer,
-    BigInt(saltBuffer.length),
-    BigInt(hashLen),
-    encodedBuffer,
-    BigInt(encodedBuffer.length),
-  );
-  if (errorCode !== 0) {
-    throw new Error(`argon2id_hash_encoded failed with error code ${errorCode}`);
-  }
-  return textDecoder.decode(encodedBuffer).replaceAll("\0", "");
-}
+export class Libargon2 {
+  private readonly lib;
 
-export function argon2idVerify(encoded: string, pwd: string): boolean {
-  const encodedBuffer = new Uint8Array(ENCODED_BUFFER_SIZE);
-  textEncoder.encodeInto(encoded, encodedBuffer);
-  const pwdBuffer = textEncoder.encode(pwd.normalize("NFKC"));
-  const errorCode = libargon2.symbols.argon2id_verify(
-    encodedBuffer,
-    pwdBuffer,
-    BigInt(pwdBuffer.length),
-  );
-  return errorCode === 0;
+  public constructor() {
+    // SAFETY: even if the FFI fails, the code will error out, so the user will get a 5xx error, which is bad, but safe
+    this.lib = Deno.dlopen(
+      "/usr/lib/x86_64-linux-gnu/libargon2.so.1", // sudo apt install libargon2-1
+      {
+        /*
+  int argon2id_hash_encoded(const uint32_t t_cost,
+                            const uint32_t m_cost,
+                            const uint32_t parallelism,
+                            const void *pwd, const size_t pwdlen,
+                            const void *salt, const size_t saltlen,
+                            const size_t hashlen, char *encoded,
+                            const size_t encodedlen);
+      */
+        "argon2id_hash_encoded": {
+          parameters: ["u32", "u32", "u32", "buffer", "usize", "buffer", "usize", "usize", "buffer", "usize"],
+          result: "i32",
+        },
+        /*
+  int argon2id_verify(const char *encoded, const void *pwd,
+                      const size_t pwdlen);
+      */
+        "argon2id_verify": {
+          parameters: ["buffer", "buffer", "usize"],
+          result: "i32",
+        },
+      },
+    );
+  }
+
+  [Symbol.dispose]() {
+    this.lib.close();
+  }
+
+  argon2idHashEncoded(
+    tCost: number,
+    mCost: number,
+    parallelism: number,
+    pwd: string,
+    saltBuffer: Uint8Array,
+    hashLen: number,
+  ): string {
+    const pwdBuffer = textEncoder.encode(pwd.normalize("NFKC"));
+    const encodedBuffer = new Uint8Array(ENCODED_BUFFER_SIZE);
+    const errorCode = this.lib.symbols.argon2id_hash_encoded(
+      tCost,
+      mCost,
+      parallelism,
+      pwdBuffer,
+      BigInt(pwdBuffer.length),
+      saltBuffer,
+      BigInt(saltBuffer.length),
+      BigInt(hashLen),
+      encodedBuffer,
+      BigInt(encodedBuffer.length),
+    );
+    if (errorCode !== 0) {
+      throw new Error(`argon2id_hash_encoded failed with error code ${errorCode}`);
+    }
+    return textDecoder.decode(encodedBuffer).replaceAll("\0", "");
+  }
+
+  argon2idVerify(encoded: string, pwd: string): boolean {
+    const encodedBuffer = new Uint8Array(ENCODED_BUFFER_SIZE);
+    textEncoder.encodeInto(encoded, encodedBuffer);
+    const pwdBuffer = textEncoder.encode(pwd.normalize("NFKC"));
+    const errorCode = this.lib.symbols.argon2id_verify(
+      encodedBuffer,
+      pwdBuffer,
+      BigInt(pwdBuffer.length),
+    );
+    return errorCode === 0;
+  }
 }

--- a/implementation/jobberknoll/app/security/passwords.ts
+++ b/implementation/jobberknoll/app/security/passwords.ts
@@ -1,4 +1,4 @@
-import { argon2idHashEncoded, argon2idVerify } from "./libargon2.ts";
+import { Libargon2 } from "./libargon2.ts";
 
 // SAFETY: according to OWASP recommendations (https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id)
 const ARGON2ID_T_COST = 5;
@@ -10,9 +10,10 @@ const ARGON2ID_SALT_LEN = 16;
 const randomBytes = (length: number) => crypto.getRandomValues(new Uint8Array(length));
 
 export function hashPassword(userPassword: string): Promise<string> {
+  using libargon2 = new Libargon2();
   const saltBuffer = randomBytes(ARGON2ID_SALT_LEN);
   return Promise.resolve(
-    argon2idHashEncoded(
+    libargon2.argon2idHashEncoded(
       ARGON2ID_T_COST,
       ARGON2ID_M_COST,
       ARGON2ID_PARALLELISM,
@@ -24,7 +25,8 @@ export function hashPassword(userPassword: string): Promise<string> {
 }
 
 export function verifyPassword(userPassword: string, phcHash: string): Promise<boolean> {
-  return Promise.resolve(argon2idVerify(phcHash, userPassword));
+  using libargon2 = new Libargon2();
+  return Promise.resolve(libargon2.argon2idVerify(phcHash, userPassword));
 }
 
 // SAFETY: this function is only used in tests


### PR DESCRIPTION
This solves two issues:
- the dynamic library is now properly closed after usage (@mlodybercik reported this issue before, but we decided to ignore it for now)
- `libargon2` is not required to use Jobberknoll as a library (as opposed to binary), so namely, Feather no longer needs `libargon2` or `--allow-ffi`