### PR TITLE
Clabbert - Fix no header parameter in external openapi swagger

### DIFF
--- a/implementation/clabbert/src/main/java/pwr/jakprzyjade/clabbert/configurations/OpenApiConfig.java
+++ b/implementation/clabbert/src/main/java/pwr/jakprzyjade/clabbert/configurations/OpenApiConfig.java
@@ -49,7 +49,12 @@ public class OpenApiConfig {
 
     @Bean
     GroupedOpenApi externalApi() {
-        return GroupedOpenApi.builder().group("external").pathsToMatch("/ext/**").build();
+        return GroupedOpenApi.builder()
+                .group("external")
+                .pathsToMatch("/ext/**")
+                .addOperationCustomizer(addUserIdHeader())
+                .addOperationCustomizer(addUserRoleHeader())
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
- fix no header parameter in external openapi swagger